### PR TITLE
Let codex entries for critters and plants be registered and auto loaded

### DIFF
--- a/PLib/Codex/PCodex.cs
+++ b/PLib/Codex/PCodex.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using Klei;
+using Harmony;
+
+namespace PeterHan.PLib.Codex {
+	public sealed class PCodex {
+
+		private static void RegisterEntry(Assembly modAssembly, string lockKey, string tableKey, string entryPath, string debugLine) {
+			// Store the path to the creatures folder on disk for use in loading codex entries
+			string dir = Options.POptions.GetModDir(modAssembly);
+			lock (PSharedData.GetLock(lockKey)) {
+				var table = PSharedData.GetData<List<string>>(tableKey);
+				if (table == null)
+					PSharedData.PutData(tableKey, table = new
+						List<string>(8));
+#if DEBUG
+				PUtil.LogDebug(debugLine.F(dir));
+#endif
+				table.Add(Path.Combine(dir, entryPath));
+			}
+		}
+
+		public static void RegisterCreatures() {
+			var assembly = Assembly.GetCallingAssembly();
+			RegisterEntry(assembly, PRegistry.KEY_CODEX_CREATURES_LOCK, PRegistry.KEY_CODEX_CREATURES_TABLE,
+				"codex/Creatures", "Registered codex creatures directory: {0}");
+		}
+
+		public static void RegisterPlants() {
+			var assembly = Assembly.GetCallingAssembly();
+			RegisterEntry(assembly, PRegistry.KEY_CODEX_PLANTS_LOCK, PRegistry.KEY_CODEX_PLANTS_TABLE,
+				"codex/Plants", "Registered codex plants directory: {0}");
+		}
+
+		private static List<CodexEntry> LoadEntries(string lockKey, string tableKey, string category) {
+			List<CodexEntry> entries = new List<CodexEntry>();
+			lock (PSharedData.GetLock(lockKey)) {
+				var table = PSharedData.GetData<List<string>>(tableKey);
+				if (table == null)
+					return entries;
+				foreach (string dir in table) {
+#if DEBUG
+					PUtil.LogDebug("Loaded codex entries from directory: {0}".F(dir));
+#endif
+					string[] strArray = new string[0];
+					try {
+						strArray = Directory.GetFiles(dir, "*.yaml");
+					}
+					catch (UnauthorizedAccessException ex) {
+						Debug.LogWarning(ex);
+					}
+					foreach (string str in strArray) {
+						try {
+							string filename = str;
+							YamlIO.ErrorHandler fMgCache0 = new YamlIO.ErrorHandler(PUtil.YamlParseErrorCB);
+							List<Tuple<string, Type>> widgetTagMappings = Traverse.Create(typeof(CodexCache)).Field("widgetTagMappings").GetValue<List<Tuple<string, Type>>>();
+							CodexEntry codexEntry = YamlIO.LoadFile<CodexEntry>(filename, fMgCache0, widgetTagMappings);
+							if (codexEntry != null) {
+								codexEntry.category = category;
+								entries.Add(codexEntry);
+							}
+						}
+						catch (Exception ex) {
+							DebugUtil.DevLogErrorFormat("CodexCache.CollectEntries failed to load [{0}]: {1}", str, ex.ToString());
+						}
+					}
+				}
+			}
+			return entries;
+		}
+
+		internal static List<CodexEntry> LoadCreaturesEntries() {
+			return LoadEntries(PRegistry.KEY_CODEX_CREATURES_LOCK,
+				PRegistry.KEY_CODEX_CREATURES_TABLE, "CREATURES");
+		}
+
+		internal static List<CodexEntry> LoadPlantsEntries() {
+			return LoadEntries(PRegistry.KEY_CODEX_PLANTS_LOCK,
+				PRegistry.KEY_CODEX_PLANTS_TABLE, "PLANTS");
+		}
+
+		private static List<SubEntry> LoadSubEntries(string lockKey, string tableKey) {
+			List<SubEntry> entries = new List<SubEntry>();
+			lock (PSharedData.GetLock(lockKey)) {
+				var table = PSharedData.GetData<List<string>>(tableKey);
+				if (table == null)
+					return entries;
+				foreach (string dir in table) {
+#if DEBUG
+					PUtil.LogDebug("Loaded codex sub entries from directory: {0}".F(dir));
+#endif
+					string[] strArray = new string[0];
+					try {
+						strArray = Directory.GetFiles(dir, "*.yaml", SearchOption.AllDirectories);
+					}
+					catch (UnauthorizedAccessException ex) {
+						Debug.LogWarning(ex);
+					}
+					foreach (string str in strArray) {
+						try {
+							string filename = str;
+							YamlIO.ErrorHandler fMgCache1 = new YamlIO.ErrorHandler(PUtil.YamlParseErrorCB);
+							List<Tuple<string, Type>> widgetTagMappings = Traverse.Create(typeof(CodexCache)).Field("widgetTagMappings").GetValue<List<Tuple<string, Type>>>();
+							SubEntry subEntry = YamlIO.LoadFile<SubEntry>(filename, fMgCache1, widgetTagMappings);
+							if (entries != null)
+								entries.Add(subEntry);
+						} catch (Exception ex) {
+							DebugUtil.DevLogErrorFormat("CodexCache.CollectSubEntries failed to load [{0}]: {1}", str, ex.ToString());
+						}
+					}
+				}
+			}
+			return entries;
+		}
+
+		internal static List<SubEntry> LoadCreaturesSubEntries() {
+			return LoadSubEntries(PRegistry.KEY_CODEX_CREATURES_LOCK,
+				PRegistry.KEY_CODEX_CREATURES_TABLE);
+		}
+
+		internal static List<SubEntry> LoadPlantsSubEntries() {
+			return LoadSubEntries(PRegistry.KEY_CODEX_PLANTS_LOCK,
+				PRegistry.KEY_CODEX_PLANTS_TABLE);
+		}
+	}
+}

--- a/PLib/Utils/PRegistry.cs
+++ b/PLib/Utils/PRegistry.cs
@@ -56,6 +56,26 @@ namespace PeterHan.PLib {
 		public const string KEY_BUILDING_TABLE = "PLib.Building.Table";
 
 		/// <summary>
+		/// Used to synchronize access to PLib codex creature dirs.
+		/// </summary>
+		public const string KEY_CODEX_CREATURES_LOCK = "PLib.Codex.Creatures.Lock";
+
+		/// <summary>
+		/// Stores the paths to the codex creature dirs.
+		/// </summary>
+		public const string KEY_CODEX_CREATURES_TABLE = "PLib.Codex.Creatures.Table";
+
+		/// <summary>
+		/// Used to synchronize access to PLib codex plant dirs.
+		/// </summary>
+		public const string KEY_CODEX_PLANTS_LOCK = "PLib.Codex.Plants.Lock";
+
+		/// <summary>
+		/// Stores the paths to the codex plant dirs.
+		/// </summary>
+		public const string KEY_CODEX_PLANTS_TABLE = "PLib.Codex.Plants.Table";
+
+		/// <summary>
 		/// Used to synchronize access to PLib.Lighting data.
 		/// </summary>
 		public const string KEY_LIGHTING_LOCK = "PLib.Lighting.Lock";

--- a/PLib/Utils/PUtil.cs
+++ b/PLib/Utils/PUtil.cs
@@ -139,7 +139,7 @@ namespace PeterHan.PLib {
 			double dx = x2 - x1, dy = y2 - y1;
 			return Math.Sqrt(dx * dx + dy * dy);
 		}
-		
+
 		/// <summary>
 		/// Executes all post-load handlers.
 		/// </summary>
@@ -292,6 +292,15 @@ namespace PeterHan.PLib {
 		[Obsolete("LoadSprite(path, Vector4, bool) allows the use of PNG/JPG images which scale far better")]
 		public static Sprite LoadSprite(string path, int width, int height, Vector4 border) {
 			return UI.PUIUtils.LoadSpriteLegacy(path, width, height, border);
+		}
+
+		/// <summary>
+		/// Callback function for the YAML parser to process errors that it throws.
+		/// </summary>
+		/// <param name="error">The YAML parsing error</param>
+		/// <param name="force_log_as_warning">Unused but matches expected callback type signature</param>
+		public static void YamlParseErrorCB(YamlIO.Error error, bool force_log_as_warning) {
+			throw new Exception(string.Format("{0} parse error in {1}\n{2}", error.severity, error.file.full_path, error.message), error.inner_exception);
 		}
 
 		/// <summary>


### PR DESCRIPTION
Loads from "codex/Creatures" and "codex/Plants" in the user's mods directory. Acts as a way to properly load codex layerable files while the game currently doesn't load them correctly.

Users of lib just need to do something like this to get it loaded:
```c#
namespace Codex
{
    public class CodexPatches
    {
        public static void OnLoad()
        {
            PeterHan.PLib.PUtil.InitLibrary();
            PeterHan.PLib.Codex.PCodex.RegisterCreatures();
            PeterHan.PLib.Codex.PCodex.RegisterPlants();
        }
    }
}
```

only attempts to load yaml files from these directories if the user explicitly called `RegisterCreatures` or `RegisterPlants` in order to be backward compatible.