### PR TITLE
Add localization for Options UI for Plib and PLibOptions.

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
+  <Target Name="PLibTranslationEmbeddedResources" BeforeTargets="ResolveReferences" Condition=" '$(AssemblyName)' == 'PLib' Or '$(AssemblyName)' == 'PLibOptions' ">
+    <ItemGroup>
+      <PLibTranslationFiles Include="../PLib/translations/*.po" />
+    </ItemGroup>
+    <ItemGroup>
+      <EmbeddedResource Include="%(PLibTranslationFiles.Identity)"
+        LogicalName="PeterHan.PLib.UI.PUIStrings.%(PLibTranslationFiles.Filename)%(PLibTranslationFiles.Extension)" />
+    </ItemGroup>
+  </Target>
+
   <Target Name="ClearGameFolderCopyLocal" AfterTargets="ResolveAssemblyReferences">
     <ItemGroup>
       <ReferenceCopyLocalPaths Remove="$(GameFolder)\*" />

--- a/PLib/Datafiles/PLocalizationItself.cs
+++ b/PLib/Datafiles/PLocalizationItself.cs
@@ -1,0 +1,74 @@
+﻿/*
+ * Copyright 2020 Peter Han
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+using PeterHan.PLib.UI;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Text;
+
+namespace PeterHan.PLib.Datafiles {
+	/// <summary>
+	/// Handles localization POptions UI for mods by automatically loading po files
+	/// stored as EmbeddedResources in Plib.dll and ILmerged with mod assembly.
+	/// </summary>
+	internal static class PLocalizationItself {
+
+		/// <summary>
+		/// The Prefix of LogicalName of EmbeddedResources that stores the content of po files
+		/// Must match the specified value in the Directory.Build.targets file
+		/// </summary>
+		private const string TRANSLATIONS_EMBEDDEDRESOURCE_PREFIX = "PeterHan.PLib.UI.PUIStrings.";
+
+		/// <summary>
+		/// The file extension used for localization files.
+		/// </summary>
+		private const string TRANSLATIONS_EXT = ".po";
+
+		/// <summary>
+		/// Localizes the POptions UI.
+		/// </summary>
+		/// <param name="locale">The locale to use.</param>
+		internal static void LocalizeItself(Localization.Locale locale) {
+			if (locale == null)
+				throw new ArgumentNullException("locale");
+			Localization.RegisterForTranslation(typeof(PUIStrings));
+			Assembly assembly = Assembly.GetExecutingAssembly();
+			try {
+				using (var stream = assembly.GetManifestResourceStream(TRANSLATIONS_EMBEDDEDRESOURCE_PREFIX + locale.Code + TRANSLATIONS_EXT)) {
+					if (stream != null) {
+						var lines = new List<string>();
+						using (var reader = new StreamReader(stream, Encoding.UTF8)) {
+							string line;
+							while ((line = reader.ReadLine()) != null)
+								lines.Add(line);
+						}
+						Localization.OverloadStrings(Localization.ExtractTranslatedStrings(lines.ToArray()));
+#if DEBUG
+						PUtil.LogDebug("Localizing Plib itself to locale {0}".F(locale.Code));
+#endif
+					}
+				}
+			} catch (Exception e) {
+				PUtil.LogWarning("Failed to load {0} localization for Plib itself:".F(locale.Code));
+				PUtil.LogExcWarn(e);
+			}
+		}
+	}
+}

--- a/PLib/PLib.csproj
+++ b/PLib/PLib.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net40</TargetFramework>
     <Title>PeterHan.PLib</Title>
     <AssemblyTitle>PeterHanLib</AssemblyTitle>
-    <Version>3.12.0.0</Version>
+    <Version>3.12.1.0</Version>
     <!--<PackageVersion>3.12.0-beta</PackageVersion>-->
     <UsesPLib>false</UsesPLib>
     <Authors>Peter Han (https://github.com/peterhaneve)</Authors>

--- a/PLib/PLibPatches.cs
+++ b/PLib/PLibPatches.cs
@@ -474,8 +474,10 @@ namespace PeterHan.PLib {
 
 			// PLocalization
 			var locale = Localization.GetLocale();
-			if (locale != null)
+			if (locale != null) { 
 				PLocalization.LocalizeAll(locale);
+				PLocalizationItself.LocalizeItself(locale);
+			}
 
 			// ModsScreen
 			POptions.Init();

--- a/PLib/PVersion.cs
+++ b/PLib/PVersion.cs
@@ -27,7 +27,7 @@ namespace PeterHan.PLib {
 		/// <summary>
 		/// The PLib version.
 		/// </summary>
-		public const string VERSION = "3.12.0.0";
+		public const string VERSION = "3.12.1.0";
 
 		/// <summary>
 		/// Reports whether the PLib version included or referenced by this mod is the latest

--- a/PLib/translations/ru.po
+++ b/PLib/translations/ru.po
@@ -1,0 +1,75 @@
+msgid ""
+msgstr ""
+"Application: Oxygen Not Included"
+"POT Version: 2.0"
+
+#. PeterHan.PLib.UI.PUIStrings.BUTTON_MANUAL
+msgctxt "PeterHan.PLib.UI.PUIStrings.BUTTON_MANUAL"
+msgid "MANUAL CONFIG"
+msgstr "РУЧНАЯ НАСТРОЙКА"
+
+#. PeterHan.PLib.UI.PUIStrings.DIALOG_TITLE
+msgctxt "PeterHan.PLib.UI.PUIStrings.DIALOG_TITLE"
+msgid "Options for {0}"
+msgstr "Настройки для {0}"
+
+#. PeterHan.PLib.UI.PUIStrings.MOD_ASSEMBLY_VERSION
+msgctxt "PeterHan.PLib.UI.PUIStrings.MOD_ASSEMBLY_VERSION"
+msgid "Assembly Version: {0}"
+msgstr "Версия сборки: {0}"
+
+#. PeterHan.PLib.UI.PUIStrings.MOD_HOMEPAGE
+msgctxt "PeterHan.PLib.UI.PUIStrings.MOD_HOMEPAGE"
+msgid "Mod Homepage"
+msgstr "Страница мода"
+
+#. PeterHan.PLib.UI.PUIStrings.MOD_VERSION
+msgctxt "PeterHan.PLib.UI.PUIStrings.MOD_VERSION"
+msgid "Mod Version: {0}"
+msgstr "Версия мода: {0}"
+
+#. PeterHan.PLib.UI.PUIStrings.RESTART_REQUIRED
+msgctxt "PeterHan.PLib.UI.PUIStrings.RESTART_REQUIRED"
+msgid "Oxygen Not Included must be restarted for these options to take effect."
+msgstr "Чтобы эти параметры вступили в силу, необходимо перезапустить Oxygen Not Included."
+
+#. PeterHan.PLib.UI.PUIStrings.TOOLTIP_CANCEL
+msgctxt "PeterHan.PLib.UI.PUIStrings.TOOLTIP_CANCEL"
+msgid "Discard changes."
+msgstr "Отменить изменения."
+
+#. PeterHan.PLib.UI.PUIStrings.TOOLTIP_HOMEPAGE
+msgctxt "PeterHan.PLib.UI.PUIStrings.TOOLTIP_HOMEPAGE"
+msgid "Visit the mod's website."
+msgstr "Посетите сайт мода."
+
+#. PeterHan.PLib.UI.PUIStrings.TOOLTIP_MANUAL
+msgctxt "PeterHan.PLib.UI.PUIStrings.TOOLTIP_MANUAL"
+msgid "Opens the folder containing the full mod configuration."
+msgstr "Открыть папку, содержащую полную конфигурацию мода."
+
+#. PeterHan.PLib.UI.PUIStrings.TOOLTIP_NEXT
+msgctxt "PeterHan.PLib.UI.PUIStrings.TOOLTIP_NEXT"
+msgid "Next"
+msgstr "Следующий"
+
+#. PeterHan.PLib.UI.PUIStrings.TOOLTIP_OK
+msgctxt "PeterHan.PLib.UI.PUIStrings.TOOLTIP_OK"
+msgid "Save these options. Some mods may require a restart for the options to take effect."
+msgstr "Сохранить эти параметры. Для некоторых модов может потребоваться перезапуск, чтобы параметры вступили в силу."
+
+#. PeterHan.PLib.UI.PUIStrings.TOOLTIP_PREVIOUS
+msgctxt "PeterHan.PLib.UI.PUIStrings.TOOLTIP_PREVIOUS"
+msgid "Previous"
+msgstr "Предыдущий"
+
+#. PeterHan.PLib.UI.PUIStrings.TOOLTIP_TOGGLE
+msgctxt "PeterHan.PLib.UI.PUIStrings.TOOLTIP_TOGGLE"
+msgid "Show or hide this options category"
+msgstr "Показать или скрыть эту категорию настроек"
+
+#. PeterHan.PLib.UI.PUIStrings.TOOLTIP_VERSION
+msgctxt "PeterHan.PLib.UI.PUIStrings.TOOLTIP_VERSION"
+msgid "The currently installed version of this mod.\n\nCompare this version with the mod's Release Notes to see if it is outdated."
+msgstr "Текущая установленная версия этого мода.\n\nСравните эту версию с примечаниями к выпуску мода, чтобы узнать, не устарела ли она."
+

--- a/PLib/translations/template.pot
+++ b/PLib/translations/template.pot
@@ -1,0 +1,75 @@
+msgid ""
+msgstr ""
+"Application: Oxygen Not Included"
+"POT Version: 2.0"
+
+#. PeterHan.PLib.UI.PUIStrings.BUTTON_MANUAL
+msgctxt "PeterHan.PLib.UI.PUIStrings.BUTTON_MANUAL"
+msgid "MANUAL CONFIG"
+msgstr ""
+
+#. PeterHan.PLib.UI.PUIStrings.DIALOG_TITLE
+msgctxt "PeterHan.PLib.UI.PUIStrings.DIALOG_TITLE"
+msgid "Options for {0}"
+msgstr ""
+
+#. PeterHan.PLib.UI.PUIStrings.MOD_ASSEMBLY_VERSION
+msgctxt "PeterHan.PLib.UI.PUIStrings.MOD_ASSEMBLY_VERSION"
+msgid "Assembly Version: {0}"
+msgstr ""
+
+#. PeterHan.PLib.UI.PUIStrings.MOD_HOMEPAGE
+msgctxt "PeterHan.PLib.UI.PUIStrings.MOD_HOMEPAGE"
+msgid "Mod Homepage"
+msgstr ""
+
+#. PeterHan.PLib.UI.PUIStrings.MOD_VERSION
+msgctxt "PeterHan.PLib.UI.PUIStrings.MOD_VERSION"
+msgid "Mod Version: {0}"
+msgstr ""
+
+#. PeterHan.PLib.UI.PUIStrings.RESTART_REQUIRED
+msgctxt "PeterHan.PLib.UI.PUIStrings.RESTART_REQUIRED"
+msgid "Oxygen Not Included must be restarted for these options to take effect."
+msgstr ""
+
+#. PeterHan.PLib.UI.PUIStrings.TOOLTIP_CANCEL
+msgctxt "PeterHan.PLib.UI.PUIStrings.TOOLTIP_CANCEL"
+msgid "Discard changes."
+msgstr ""
+
+#. PeterHan.PLib.UI.PUIStrings.TOOLTIP_HOMEPAGE
+msgctxt "PeterHan.PLib.UI.PUIStrings.TOOLTIP_HOMEPAGE"
+msgid "Visit the mod's website."
+msgstr ""
+
+#. PeterHan.PLib.UI.PUIStrings.TOOLTIP_MANUAL
+msgctxt "PeterHan.PLib.UI.PUIStrings.TOOLTIP_MANUAL"
+msgid "Opens the folder containing the full mod configuration."
+msgstr ""
+
+#. PeterHan.PLib.UI.PUIStrings.TOOLTIP_NEXT
+msgctxt "PeterHan.PLib.UI.PUIStrings.TOOLTIP_NEXT"
+msgid "Next"
+msgstr ""
+
+#. PeterHan.PLib.UI.PUIStrings.TOOLTIP_OK
+msgctxt "PeterHan.PLib.UI.PUIStrings.TOOLTIP_OK"
+msgid "Save these options. Some mods may require a restart for the options to take effect."
+msgstr ""
+
+#. PeterHan.PLib.UI.PUIStrings.TOOLTIP_PREVIOUS
+msgctxt "PeterHan.PLib.UI.PUIStrings.TOOLTIP_PREVIOUS"
+msgid "Previous"
+msgstr ""
+
+#. PeterHan.PLib.UI.PUIStrings.TOOLTIP_TOGGLE
+msgctxt "PeterHan.PLib.UI.PUIStrings.TOOLTIP_TOGGLE"
+msgid "Show or hide this options category"
+msgstr ""
+
+#. PeterHan.PLib.UI.PUIStrings.TOOLTIP_VERSION
+msgctxt "PeterHan.PLib.UI.PUIStrings.TOOLTIP_VERSION"
+msgid "The currently installed version of this mod.\n\nCompare this version with the mod's Release Notes to see if it is outdated."
+msgstr ""
+

--- a/PLibOptions/PLibOptions.csproj
+++ b/PLibOptions/PLibOptions.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net40</TargetFramework>
     <Title>PeterHan.PLib.Options</Title>
     <AssemblyTitle>PeterHanLib Options</AssemblyTitle>
-    <Version>3.8.0.0</Version>
+    <Version>3.8.1.0</Version>
     <UsesPLib>false</UsesPLib>
     <Authors>Peter Han (https://github.com/peterhaneve)</Authors>
     <Copyright>Copyright 2020 Peter Han</Copyright>
@@ -21,6 +21,7 @@ Contains functions aimed at improving cross-mod compatibility, in-game user inte
     <DocumentationFile>bin\Release\PLibOptions.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="..\PLib\Datafiles\PLocalizationItself.cs" Link="PLocalizationItself.cs" />
     <Compile Include="..\PLib\Detours\DetouredField.cs" Link="DetouredField.cs" />
     <Compile Include="..\PLib\Detours\DetouredMethod.cs" Link="DetouredMethod.cs" />
     <Compile Include="..\PLib\Detours\DetourException.cs" Link="DetourException.cs" />

--- a/PLibOptions/POptionsPatches.cs
+++ b/PLibOptions/POptionsPatches.cs
@@ -17,6 +17,7 @@
  */
 
 using Harmony;
+using PeterHan.PLib.Datafiles;
 using PeterHan.PLib.Detours;
 using System;
 using System.Collections;
@@ -52,6 +53,26 @@ namespace PeterHan.PLib.Options {
 			var manager = Global.Instance.modManager;
 			if (manager != null)
 				MODS_SAVE.Invoke(manager);
+		}
+
+		/// <summary>
+		/// Applied to GlobalResources to localize POptions UI for this mod.
+		/// </summary>
+		[HarmonyPatch(typeof(GlobalResources), "Instance")]
+		internal static class GlobalResources_Instance_Patch {
+			private static bool applied = false;
+			/// <summary>
+			/// Applied after Instance runs.
+			/// </summary>
+			internal static void Postfix() {
+				if (!applied) {
+					var locale = Localization.GetLocale();
+					if (locale != null) {
+						PLocalizationItself.LocalizeItself(locale);
+					}
+					applied = true;
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
Russian included.
The content of *.po files are stored as EmbeddedResources inside Plib.dll and PLibOptions.dll at compile time.
This does not require any additional action from modders. Modders, as before, simply ILmerge these Plib.dll or PLibOptions.dll with their assemblies.