### PR TITLE
Update russian localization

### DIFF
--- a/ModUpdateDate/ModUpdateDatePatches.cs
+++ b/ModUpdateDate/ModUpdateDatePatches.cs
@@ -21,6 +21,7 @@ using KMod;
 using PeterHan.PLib.Core;
 using PeterHan.PLib.Database;
 using PeterHan.PLib.Options;
+using PeterHan.PLib.PatchManager;
 using PeterHan.PLib.UI;
 using Steamworks;
 using System.Collections.Generic;
@@ -58,13 +59,18 @@ namespace PeterHan.ModUpdateDate {
 					nameof(OnModCrash)));
 			base.OnLoad(harmony);
 			PUtil.InitLibrary();
+			new PPatchManager(harmony).RegisterPatchClass(typeof(ModUpdateDatePatches));
 			new POptions().RegisterOptions(this, typeof(ModUpdateInfo));
-			LocString.CreateLocStringKeys(typeof(ModUpdateDateStrings.UI));
 			new PLocalization().Register();
 			ModUpdateInfo.LoadSettings();
 			ThisMod = mod;
 			// Shut off AVC
 			PRegistry.PutData("PLib.VersionCheck.ModUpdaterActive", true);
+		}
+
+		[PLibMethod(RunAt.BeforeDbInit)]
+		private static void BeforeDbInit() {
+			LocString.CreateLocStringKeys(typeof(ModUpdateDateStrings.UI));
 		}
 
 		/// <summary>

--- a/ModUpdateDate/ModUpdateHandler.cs
+++ b/ModUpdateDate/ModUpdateHandler.cs
@@ -23,6 +23,7 @@ using PeterHan.PLib.UI;
 using Steamworks;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Text;
 using UnityEngine;
@@ -76,6 +77,8 @@ namespace PeterHan.ModUpdateDate {
 			Instance = new ModUpdateHandler();
 		}
 
+		private static CultureInfo cultureInfo;
+
 		/// <summary>
 		/// Adds the mod update date to the mods menu.
 		/// </summary>
@@ -101,13 +104,22 @@ namespace PeterHan.ModUpdateDate {
 					Margin = BUTTON_MARGIN, SpriteSize = ICON_SIZE,
 					MaintainSpriteAspect = true
 				};
+				// formatting DateTime
+				if (cultureInfo == null) {
+					var langCode = Localization.GetLocale()?.Code;
+					if (string.IsNullOrEmpty(langCode))
+						langCode = Localization.GetCurrentLanguageCode();
+					if (string.IsNullOrEmpty(langCode))
+						langCode = Localization.DEFAULT_LANGUAGE_CODE;
+					cultureInfo = new CultureInfo(langCode);
+				}
 				if (mod.label.distribution_platform == Label.DistributionPlatform.Steam) {
 					var modUpdate = new ModToUpdate(mod);
 					updated = AddSteamUpdate(tooltip, modUpdate, localDate, updButton);
 					if (updated == ModStatus.Outdated)
 						outdated.Add(modUpdate);
 				} else
-					tooltip.AppendFormat(UISTRINGS.LOCAL_UPDATE, localDate.ToLocalTime());
+					tooltip.AppendFormat(cultureInfo, UISTRINGS.LOCAL_UPDATE, localDate.ToLocalTime());
 				// Icon, color, and tooltip
 				updButton.Sprite = (updated == ModStatus.UpToDate || updated == ModStatus.
 					Disabled) ? PUITuning.Images.Checked : PUITuning.Images.GetSpriteByName(
@@ -149,12 +161,12 @@ namespace PeterHan.ModUpdateDate {
 			}
 			// AppendLine appends platform specific separator
 			tooltip.Append("\n");
-			tooltip.AppendFormat(UISTRINGS.LOCAL_UPDATE, localDate.ToLocalTime());
+			tooltip.AppendFormat(cultureInfo, UISTRINGS.LOCAL_UPDATE, localDate.ToLocalTime());
 			tooltip.Append("\n");
 			if (updated == ModStatus.Disabled)
 				tooltip.AppendFormat(UISTRINGS.STEAM_UPDATE_UNKNOWN);
 			else {
-				tooltip.AppendFormat(UISTRINGS.STEAM_UPDATE, steamDate.ToLocalTime());
+				tooltip.AppendFormat(cultureInfo, UISTRINGS.STEAM_UPDATE, steamDate.ToLocalTime());
 				updButton.OnClick = new ModUpdateTask(modUpdate).TryUpdateMods;
 			}
 			return updated;

--- a/ModUpdateDate/translations/ru.po
+++ b/ModUpdateDate/translations/ru.po
@@ -1,0 +1,191 @@
+msgid ""
+msgstr ""
+"Application: Oxygen Not Included\n"
+"POT Version: 2.0\n"
+"Project-Id-Version: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.0.6\n"
+"Last-Translator: \n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Language: ru\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.CONFIRM_CANCEL
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.CONFIRM_CANCEL"
+msgid "CANCEL"
+msgstr "ОТМЕНА"
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.CONFIRM_LINE
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.CONFIRM_LINE"
+msgid "<b>{0}</b>\n"
+msgstr "<b>{0}</b>\n"
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.CONFIRM_MORE
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.CONFIRM_MORE"
+msgid "<i>(and {0:D} more...)</i>\n"
+msgstr "<i>(и ещё {0:D}...)</i>\n"
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.CONFIRM_OK
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.CONFIRM_OK"
+msgid "FORCE UPDATE"
+msgstr "ОБНОВИТЬ ПРИНУДИТЕЛЬНО"
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.CONFIRM_UPDATE
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.CONFIRM_UPDATE"
+msgid "Continuing will reinstall the latest version of:\n{0}from the Workshop.\n<color=#FFCC00>A best effort will be made to preserve mod options.</color>\n\nCheck again after updating and enable the mod if necessary."
+msgstr "Продолжение переустановит последнюю версию:\n{0}из Мастерской.\n<color=#FFCC00>Будут приложены все усилия, чтобы сохранить настройки мода.</color>\n\nПроверьте еще раз после обновления и при необходимости включите мод."
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.LOCAL_UPDATE
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.LOCAL_UPDATE"
+msgid "<b>Local Updated:</b> {0:f}"
+msgstr "<b>Локальное Обновление:</b> {0:f}"
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MAINMENU_UPDATE
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MAINMENU_UPDATE"
+msgid "\n\n<color=#FFCC00>{0:D} mods may be out of date</color>"
+msgstr "\n\n<color=#FFCC00>{0:D} мода(-ов) могут быть устаревшими</color>"
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MAINMENU_UPDATE_1
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MAINMENU_UPDATE_1"
+msgid "\n\n<color=#FFCC00>1 mod may be out of date</color>"
+msgstr "\n\n<color=#FFCC00>1 мод может быть устаревшим</color>"
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MOD_OUTDATED
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MOD_OUTDATED"
+msgid "This mod appears to be out of date!"
+msgstr "Этот мод очевидно устарел!"
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MOD_UPDATE_1
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MOD_UPDATE_1"
+msgid "Update one mod which appears to be out of date"
+msgstr "Обновить один мод, который очевидно устарел"
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MOD_UPDATE_ALL
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MOD_UPDATE_ALL"
+msgid "Update {0:D} mods which appear to be out of date"
+msgstr "Обновить {0:D} мода(-ов), которые очевидно устарели"
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MOD_UPDATED
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MOD_UPDATED"
+msgid "This mod appears to be up to date."
+msgstr "Этот мод очевидно обновлен."
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MOD_UPDATED_BYUS
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MOD_UPDATED_BYUS"
+msgid "This mod was locally updated by Mod Updater."
+msgstr "Этот мод был локально обновлен Mod Updater-ом."
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.OPTION_MAINMENU
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.OPTION_MAINMENU"
+msgid "Show Updates in Main Menu"
+msgstr "Показывать обновления в Главном меню"
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.STEAM_UPDATE
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.STEAM_UPDATE"
+msgid "<b>Steam Updated:</b> {0:f}"
+msgstr "<b>Обновление в Steam:</b> {0:f}"
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.STEAM_UPDATE_UNKNOWN
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.STEAM_UPDATE_UNKNOWN"
+msgid "<b>Steam Updated</b>: Unknown"
+msgstr "<b>Обновление в Steam</b>: Неизвестно"
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_CANTSTART
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_CANTSTART"
+msgid "Unable to start download"
+msgstr "Не удалось запустить загрузку"
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_ERROR
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_ERROR"
+msgid "<b>{0}</b>: <color=#FF0000>{1}</color>\n"
+msgstr "<b>{0}</b>: <color=#FF0000>{1}</color>\n"
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_FOOTER_CONFIG
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_FOOTER_CONFIG"
+msgid "\n<b><color=#FFCC00>Back up any valuable mod configurations now manually!</color></b>"
+msgstr "\n<b><color=#FFCC00>Теперь создайте вручную резервные копии любых ценных конфигураций модов!</color></b>"
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_FOOTER_ERROR
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_FOOTER_ERROR"
+msgid "\nCheck your connection, and that the mods directory has sufficient disk space and permissions."
+msgstr "\nПроверьте свое подключение и убедитесь, что в каталоге mods достаточно места на диске и разрешений."
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_FOOTER_OK
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_FOOTER_OK"
+msgid "\n{0} will be updated on the next restart."
+msgstr "\n{0} при следующем перезапуске."
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_HEADER
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_HEADER"
+msgid "<size=16>Update results:</size>\n\n"
+msgstr "<size=16>Результаты обновления:</size>\n\n"
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_INPROGRESS
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_INPROGRESS"
+msgid "An update for another mod is already in progress."
+msgstr "Обновление для другого мода уже выполняется."
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_MULTIPLE
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_MULTIPLE"
+msgid "These mods"
+msgstr "Эти моды будут обновлены"
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_NODETAILS
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_NODETAILS"
+msgid "Uninstalled or not found on workshop"
+msgstr "Удалено или не найдено в Мастерской"
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_NOFILE
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_NOFILE"
+msgid "No file found to download"
+msgstr "Файл для загрузки не найден"
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_OFFLINE
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_OFFLINE"
+msgid "Cannot download in Offline Mode"
+msgstr "Нельзя загрузить в автономном режиме"
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_OK_CONFIG
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_OK_CONFIG"
+msgid "<b>{0}</b>: <color=#00CC00>{1:D} custom mod option files backed up</color>\n"
+msgstr "<b>{0}</b>: <color=#00CC00>{1:D} файлов с настройками модов забэкаплены</color>\n"
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_OK_CONFIG_1
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_OK_CONFIG_1"
+msgid "<b>{0}</b>: <color=#00CC00>One custom mod option file backed up</color>\n"
+msgstr "<b>{0}</b>: <color=#00CC00>Один файл с настройками модов забэкаплен</color>\n"
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_OK_NOCONFIG
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_OK_NOCONFIG"
+msgid "<b>{0}</b>: <color=#FFCC00>Unable to back up configuration files</color>\n"
+msgstr "<b>{0}</b>: <color=#FFCC00>Не удается создать резервную копию файлов конфигурации</color>\n"
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_ONE
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_ONE"
+msgid "This mod"
+msgstr "Этот мод будет обновлен"
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_REST
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_REST"
+msgid "<b>{0:D}</b> <color=#00CC00>mods were updated with no errors</color>\n"
+msgstr "<b>{0:D}</b> <color=#00CC00>мода(-ов) были обновлены без ошибок</color>\n"
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_REST_1
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_REST_1"
+msgid "<b>One</b> <color=#00CC00>mod was updated with no errors</color>\n"
+msgstr "<b>Один</b> <color=#00CC00>мод был обновлен без ошибок</color>\n"
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_SINGLE
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_SINGLE"
+msgid "<b>{0}</b>: <color=#00CC00>Updated</color>\n"
+msgstr "<b>{0}</b>: <color=#00CC00>Обновлено</color>\n"
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.TOOLTIPS.MODUPDATER.OPTION_MAINMENU
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.TOOLTIPS.MODUPDATER.OPTION_MAINMENU"
+msgid "If selected, a warning with the number of potentially\noutdated mods is shown in the main menu."
+msgstr "Если включено, в главном меню отображается предупреждение\nс количеством потенциально устаревших модов."

--- a/ModUpdateDate/translations/template.pot
+++ b/ModUpdateDate/translations/template.pot
@@ -1,0 +1,180 @@
+msgid ""
+msgstr ""
+"Application: Oxygen Not Included"
+"POT Version: 2.0"
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.CONFIRM_CANCEL
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.CONFIRM_CANCEL"
+msgid "CANCEL"
+msgstr ""
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.CONFIRM_LINE
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.CONFIRM_LINE"
+msgid "<b>{0}</b>\n"
+msgstr ""
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.CONFIRM_MORE
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.CONFIRM_MORE"
+msgid "<i>(and {0:D} more...)</i>\n"
+msgstr ""
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.CONFIRM_OK
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.CONFIRM_OK"
+msgid "FORCE UPDATE"
+msgstr ""
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.CONFIRM_UPDATE
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.CONFIRM_UPDATE"
+msgid "Continuing will reinstall the latest version of:\n{0}from the Workshop.\n<color=#FFCC00>A best effort will be made to preserve mod options.</color>\n\nCheck again after updating and enable the mod if necessary."
+msgstr ""
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.LOCAL_UPDATE
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.LOCAL_UPDATE"
+msgid "<b>Local Updated:</b> {0:f}"
+msgstr ""
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MAINMENU_UPDATE
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MAINMENU_UPDATE"
+msgid "\n\n<color=#FFCC00>{0:D} mods may be out of date</color>"
+msgstr ""
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MAINMENU_UPDATE_1
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MAINMENU_UPDATE_1"
+msgid "\n\n<color=#FFCC00>1 mod may be out of date</color>"
+msgstr ""
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MOD_OUTDATED
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MOD_OUTDATED"
+msgid "This mod appears to be out of date!"
+msgstr ""
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MOD_UPDATE_1
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MOD_UPDATE_1"
+msgid "Update one mod which appears to be out of date"
+msgstr ""
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MOD_UPDATE_ALL
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MOD_UPDATE_ALL"
+msgid "Update {0:D} mods which appear to be out of date"
+msgstr ""
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MOD_UPDATED
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MOD_UPDATED"
+msgid "This mod appears to be up to date."
+msgstr ""
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MOD_UPDATED_BYUS
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MOD_UPDATED_BYUS"
+msgid "This mod was locally updated by Mod Updater."
+msgstr ""
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.OPTION_MAINMENU
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.OPTION_MAINMENU"
+msgid "Show Updates in Main Menu"
+msgstr ""
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.STEAM_UPDATE
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.STEAM_UPDATE"
+msgid "<b>Steam Updated:</b> {0:f}"
+msgstr ""
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.STEAM_UPDATE_UNKNOWN
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.STEAM_UPDATE_UNKNOWN"
+msgid "<b>Steam Updated</b>: Unknown"
+msgstr ""
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_CANTSTART
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_CANTSTART"
+msgid "Unable to start download"
+msgstr ""
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_ERROR
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_ERROR"
+msgid "<b>{0}</b>: <color=#FF0000>{1}</color>\n"
+msgstr ""
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_FOOTER_CONFIG
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_FOOTER_CONFIG"
+msgid "\n<b><color=#FFCC00>Back up any valuable mod configurations now manually!</color></b>"
+msgstr ""
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_FOOTER_ERROR
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_FOOTER_ERROR"
+msgid "\nCheck your connection, and that the mods directory has sufficient disk space and permissions."
+msgstr ""
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_FOOTER_OK
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_FOOTER_OK"
+msgid "\n{0} will be updated on the next restart."
+msgstr ""
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_HEADER
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_HEADER"
+msgid "<size=16>Update results:</size>\n\n"
+msgstr ""
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_INPROGRESS
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_INPROGRESS"
+msgid "An update for another mod is already in progress."
+msgstr ""
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_MULTIPLE
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_MULTIPLE"
+msgid "These mods"
+msgstr ""
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_NODETAILS
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_NODETAILS"
+msgid "Uninstalled or not found on workshop"
+msgstr ""
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_NOFILE
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_NOFILE"
+msgid "No file found to download"
+msgstr ""
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_OFFLINE
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_OFFLINE"
+msgid "Cannot download in Offline Mode"
+msgstr ""
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_OK_CONFIG
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_OK_CONFIG"
+msgid "<b>{0}</b>: <color=#00CC00>{1:D} custom mod option files backed up</color>\n"
+msgstr ""
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_OK_CONFIG_1
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_OK_CONFIG_1"
+msgid "<b>{0}</b>: <color=#00CC00>One custom mod option file backed up</color>\n"
+msgstr ""
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_OK_NOCONFIG
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_OK_NOCONFIG"
+msgid "<b>{0}</b>: <color=#FFCC00>Unable to back up configuration files</color>\n"
+msgstr ""
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_ONE
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_ONE"
+msgid "This mod"
+msgstr ""
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_REST
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_REST"
+msgid "<b>{0:D}</b> <color=#00CC00>mods were updated with no errors</color>\n"
+msgstr ""
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_REST_1
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_REST_1"
+msgid "<b>One</b> <color=#00CC00>mod was updated with no errors</color>\n"
+msgstr ""
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_SINGLE
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.UPDATE_SINGLE"
+msgid "<b>{0}</b>: <color=#00CC00>Updated</color>\n"
+msgstr ""
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.TOOLTIPS.MODUPDATER.OPTION_MAINMENU
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.TOOLTIPS.MODUPDATER.OPTION_MAINMENU"
+msgid "If selected, a warning with the number of potentially\noutdated mods is shown in the main menu."
+msgstr ""
+

--- a/PLibCore/translations/ru.po
+++ b/PLibCore/translations/ru.po
@@ -1,17 +1,60 @@
 msgid ""
 msgstr ""
-"Application: Oxygen Not Included"
-"POT Version: 2.0"
+"Application: Oxygen Not Included\n"
+"POT Version: 2.0\n"
+"Project-Id-Version:\n"
+"POT-Creation-Date:\n"
+"PO-Revision-Date:\n"
+"Language-Team:\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.0.6\n"
+"Last-Translator:\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Language: ru\n"
+"X-Poedit-SourceCharset: UTF-8\n"
 
 #. PeterHan.PLib.Core.PLibStrings.BUTTON_MANUAL
 msgctxt "PeterHan.PLib.Core.PLibStrings.BUTTON_MANUAL"
 msgid "MANUAL CONFIG"
 msgstr "РУЧНАЯ НАСТРОЙКА"
 
+#. PeterHan.PLib.Core.PLibStrings.BUTTON_RESET
+msgctxt "PeterHan.PLib.Core.PLibStrings.BUTTON_RESET"
+msgid "RESET TO DEFAULT"
+msgstr "СБРОС ПО УМОЛЧАНИЮ"
+
 #. PeterHan.PLib.Core.PLibStrings.DIALOG_TITLE
 msgctxt "PeterHan.PLib.Core.PLibStrings.DIALOG_TITLE"
 msgid "Options for {0}"
 msgstr "Настройки для {0}"
+
+#. PeterHan.PLib.Core.PLibStrings.KEY_ARROWDOWN
+msgctxt "PeterHan.PLib.Core.PLibStrings.KEY_ARROWDOWN"
+msgid "Down Arrow"
+msgstr "Стрелка Вниз"
+
+#. PeterHan.PLib.Core.PLibStrings.KEY_ARROWLEFT
+msgctxt "PeterHan.PLib.Core.PLibStrings.KEY_ARROWLEFT"
+msgid "Left Arrow"
+msgstr "Стрелка Влево"
+
+#. PeterHan.PLib.Core.PLibStrings.KEY_ARROWRIGHT
+msgctxt "PeterHan.PLib.Core.PLibStrings.KEY_ARROWRIGHT"
+msgid "Right Arrow"
+msgstr "Стрелка Вправо"
+
+#. PeterHan.PLib.Core.PLibStrings.KEY_ARROWUP
+msgctxt "PeterHan.PLib.Core.PLibStrings.KEY_ARROWUP"
+msgid "Up Arrow"
+msgstr "Стрелка Вверх"
+
+#. PeterHan.PLib.Core.PLibStrings.KEY_CATEGORY_TITLE
+msgctxt "PeterHan.PLib.Core.PLibStrings.KEY_CATEGORY_TITLE"
+msgid "Mods"
+msgstr "Моды"
 
 #. PeterHan.PLib.Core.PLibStrings.MOD_ASSEMBLY_VERSION
 msgctxt "PeterHan.PLib.Core.PLibStrings.MOD_ASSEMBLY_VERSION"
@@ -27,6 +70,16 @@ msgstr "Страница мода"
 msgctxt "PeterHan.PLib.Core.PLibStrings.MOD_VERSION"
 msgid "Mod Version: {0}"
 msgstr "Версия мода: {0}"
+
+#. PeterHan.PLib.Core.PLibStrings.OUTDATED_TOOLTIP
+msgctxt "PeterHan.PLib.Core.PLibStrings.OUTDATED_TOOLTIP"
+msgid "This mod is out of date!\nNew version: <b>{0}</b>\n\nUpdate local mods manually, or use <b>Mod Updater</b> to force update Steam mods"
+msgstr "Этот мод устарел!\nНовая версия: <b>{0}</b>\n\nОбновите локальные моды вручную или используйте <b>Mod Updater</b> для принудительного обновления модов Steam"
+
+#. PeterHan.PLib.Core.PLibStrings.OUTDATED_WARNING
+msgctxt "PeterHan.PLib.Core.PLibStrings.OUTDATED_WARNING"
+msgid "<b><style=\"logic_off\">Outdated!</style></b>"
+msgstr "<b><style=\"logic_off\">Устарел!</style></b>"
 
 #. PeterHan.PLib.Core.PLibStrings.RESTART_REQUIRED
 msgctxt "PeterHan.PLib.Core.PLibStrings.RESTART_REQUIRED"
@@ -63,6 +116,11 @@ msgctxt "PeterHan.PLib.Core.PLibStrings.TOOLTIP_PREVIOUS"
 msgid "Previous"
 msgstr "Предыдущий"
 
+#. PeterHan.PLib.Core.PLibStrings.TOOLTIP_RESET
+msgctxt "PeterHan.PLib.Core.PLibStrings.TOOLTIP_RESET"
+msgid "Resets the mod configuration to default values."
+msgstr "Сбросить конфигурацию мода до значений по умолчанию."
+
 #. PeterHan.PLib.Core.PLibStrings.TOOLTIP_TOGGLE
 msgctxt "PeterHan.PLib.Core.PLibStrings.TOOLTIP_TOGGLE"
 msgid "Show or hide this options category"
@@ -71,5 +129,5 @@ msgstr "Показать или скрыть эту категорию наст�
 #. PeterHan.PLib.Core.PLibStrings.TOOLTIP_VERSION
 msgctxt "PeterHan.PLib.Core.PLibStrings.TOOLTIP_VERSION"
 msgid "The currently installed version of this mod.\n\nCompare this version with the mod's Release Notes to see if it is outdated."
-msgstr "Текущая установленная версия этого мода.\n\nСравните эту версию с примечаниями к выпуску мода, чтобы узнать, не устарела ли она."
+msgstr "Текущая установленная версия этого мода.\n\nСравните эту версию с примечаниями к выпуску мода, чтобы узнать, не устарел ли он."
 

--- a/PLibCore/translations/template.pot
+++ b/PLibCore/translations/template.pot
@@ -8,9 +8,39 @@ msgctxt "PeterHan.PLib.Core.PLibStrings.BUTTON_MANUAL"
 msgid "MANUAL CONFIG"
 msgstr ""
 
+#. PeterHan.PLib.Core.PLibStrings.BUTTON_RESET
+msgctxt "PeterHan.PLib.Core.PLibStrings.BUTTON_RESET"
+msgid "RESET TO DEFAULT"
+msgstr ""
+
 #. PeterHan.PLib.Core.PLibStrings.DIALOG_TITLE
 msgctxt "PeterHan.PLib.Core.PLibStrings.DIALOG_TITLE"
 msgid "Options for {0}"
+msgstr ""
+
+#. PeterHan.PLib.Core.PLibStrings.KEY_ARROWDOWN
+msgctxt "PeterHan.PLib.Core.PLibStrings.KEY_ARROWDOWN"
+msgid "Down Arrow"
+msgstr ""
+
+#. PeterHan.PLib.Core.PLibStrings.KEY_ARROWLEFT
+msgctxt "PeterHan.PLib.Core.PLibStrings.KEY_ARROWLEFT"
+msgid "Left Arrow"
+msgstr ""
+
+#. PeterHan.PLib.Core.PLibStrings.KEY_ARROWRIGHT
+msgctxt "PeterHan.PLib.Core.PLibStrings.KEY_ARROWRIGHT"
+msgid "Right Arrow"
+msgstr ""
+
+#. PeterHan.PLib.Core.PLibStrings.KEY_ARROWUP
+msgctxt "PeterHan.PLib.Core.PLibStrings.KEY_ARROWUP"
+msgid "Up Arrow"
+msgstr ""
+
+#. PeterHan.PLib.Core.PLibStrings.KEY_CATEGORY_TITLE
+msgctxt "PeterHan.PLib.Core.PLibStrings.KEY_CATEGORY_TITLE"
+msgid "Mods"
 msgstr ""
 
 #. PeterHan.PLib.Core.PLibStrings.MOD_ASSEMBLY_VERSION
@@ -26,6 +56,16 @@ msgstr ""
 #. PeterHan.PLib.Core.PLibStrings.MOD_VERSION
 msgctxt "PeterHan.PLib.Core.PLibStrings.MOD_VERSION"
 msgid "Mod Version: {0}"
+msgstr ""
+
+#. PeterHan.PLib.Core.PLibStrings.OUTDATED_TOOLTIP
+msgctxt "PeterHan.PLib.Core.PLibStrings.OUTDATED_TOOLTIP"
+msgid "This mod is out of date!\nNew version: <b>{0}</b>\n\nUpdate local mods manually, or use <b>Mod Updater</b> to force update Steam mods"
+msgstr ""
+
+#. PeterHan.PLib.Core.PLibStrings.OUTDATED_WARNING
+msgctxt "PeterHan.PLib.Core.PLibStrings.OUTDATED_WARNING"
+msgid "<b><style=\"logic_off\">Outdated!</style></b>"
 msgstr ""
 
 #. PeterHan.PLib.Core.PLibStrings.RESTART_REQUIRED
@@ -61,6 +101,11 @@ msgstr ""
 #. PeterHan.PLib.Core.PLibStrings.TOOLTIP_PREVIOUS
 msgctxt "PeterHan.PLib.Core.PLibStrings.TOOLTIP_PREVIOUS"
 msgid "Previous"
+msgstr ""
+
+#. PeterHan.PLib.Core.PLibStrings.TOOLTIP_RESET
+msgctxt "PeterHan.PLib.Core.PLibStrings.TOOLTIP_RESET"
+msgid "Resets the mod configuration to default values."
 msgstr ""
 
 #. PeterHan.PLib.Core.PLibStrings.TOOLTIP_TOGGLE


### PR DESCRIPTION
1. Update russian localization for Plib.
2. Add russian localization for Mod Updater.
3. localized formatting of "Local/Steam Updated" DateTimes
![Datetimes](https://user-images.githubusercontent.com/73459473/125965132-01f145b5-61aa-46ae-a404-9e55f0b709b8.png)

4. when I was doing localization, I found that some text fragments remain untranslated.
I believe that this is due to too early calling `LocString.CreateLocStringKeys` and I suggest moving it to a later time.
for example, Mod Updater from Steam Workshop:
![steam](https://user-images.githubusercontent.com/73459473/125969104-e82cc281-0141-4c5b-a2ce-ecfd411aa4de.png)

locally patched and compiled Mod Updater:
![localpatched](https://user-images.githubusercontent.com/73459473/125969138-58f644d4-2c9c-4294-8106-9027d617267f.png)
