### PR TITLE
Fix for Fix to fix bug 25139, overjoyed reactions not triggering

### DIFF
--- a/StockBugFix/StockBugsPatches.cs
+++ b/StockBugFix/StockBugsPatches.cs
@@ -35,8 +35,9 @@ namespace PeterHan.StockBugFix {
 	public sealed class StockBugsPatches : KMod.UserMod2 {
 		/// <summary>
 		/// Base divisor is 10000, so 6000/10000 = 0.6 priority.
+		/// The default -1 value means that the auto calculated priority value will be used.
 		/// </summary>
-		public const int JOY_PRIORITY_MOD = 6000;
+		public const int JOY_PRIORITY_MOD = -1;
 
 		/// <summary>
 		/// Sets the default chore type of food storage depending on the user options. Also


### PR DESCRIPTION
I think the fix "to fix bug 25139, overjoyed reactions not triggering" doesn't work well enough.

the hardcoded value 6000 is too small.
I suggest using the default value -1 so that the auto-calculated priority value is used, just as it is done in the game for other non-working ChoreType's

now
![Снимок экрана от 2021-12-27 13-08-08](https://user-images.githubusercontent.com/73459473/147466640-597033ab-ca59-42c9-9d61-f461f6153006.png)

with my change
![Снимок экрана от 2021-12-27 14-10-54](https://user-images.githubusercontent.com/73459473/147466690-15f31966-581e-4f91-bc74-f42f1b8dd346.png)

