### PR TITLE
Update russian localization for Plib and Mod Updater.

### DIFF
--- a/ModUpdateDate/translations/ru.po
+++ b/ModUpdateDate/translations/ru.po
@@ -55,6 +55,21 @@ msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MAINMENU_UPDA
 msgid "\n\n<color=#FFCC00>1 mod may be out of date</color>"
 msgstr "\n\n<color=#FFCC00>1 мод может быть устаревшим</color>"
 
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MAINMENU_UPDATING
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MAINMENU_UPDATING"
+msgid "\n\n<color=#00CC00>Auto-Update in progress</color>"
+msgstr "\n\n<color=#00CC00>Выполняется авто-обновление</color>"
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MOD_AUTO_UPDATE
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MOD_AUTO_UPDATE"
+msgid "<b>Automatic updates are enabled.</b>\n"
+msgstr "<b>Автоматическое обновление включено.</b>\n"
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MOD_ERR_UPDATE
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MOD_ERR_UPDATE"
+msgid "Unable to automatically update this mod!\nA manual update may be required."
+msgstr "Невозможно автоматически обновить этот мод!\nМожет потребоваться обновление вручную."
+
 #. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MOD_OUTDATED
 msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MOD_OUTDATED"
 msgid "This mod appears to be out of date!"
@@ -84,6 +99,21 @@ msgstr "Этот мод был локально обновлен Mod Updater-о�
 msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.OPTION_MAINMENU"
 msgid "Show Updates in Main Menu"
 msgstr "Показывать обновления в Главном меню"
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.OPTION_PASSIVE
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.OPTION_PASSIVE"
+msgid "Auto-Update"
+msgstr "Автоматическое обновление"
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.SAFE_MODE
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.SAFE_MODE"
+msgid "<b>Mod Updater did not start correctly.</b>\n\nDue to a recent Klei update, Mod Updater was unable to start.\nSteam may automatically update Mod Updater to the latest version.\nIf not, install the latest version manually from the mod website.\n\n<b>Mod Updater version:</b> {0}\n<b>Compiled for game version:</b> {1}"
+msgstr "<b>Mod Updater запустился некорректно.</b>\n\nИз-за недавнего обновления Klei не удалось запустить Mod Updater.\nSteam может автоматически обновить Mod Updater до последней версии.\nЕсли нет, установите последнюю версию вручную с веб-сайта мода.\n\n<b>Версия Mod Updater:</b> {0}\n<b>Скомпилирован для версии игры:</b> {1}"
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.SAFE_MODE_GITHUB
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.SAFE_MODE_GITHUB"
+msgid "VISIT WEBSITE"
+msgstr "ПОСЕТИТЬ ВЕБ-САЙТ"
 
 #. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.STEAM_UPDATE
 msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.STEAM_UPDATE"
@@ -189,3 +219,9 @@ msgstr "<b>{0}</b>: <color=#00CC00>Обновлено</color>\n"
 msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.TOOLTIPS.MODUPDATER.OPTION_MAINMENU"
 msgid "If selected, a warning with the number of potentially\noutdated mods is shown in the main menu."
 msgstr "Если включено, в главном меню отображается предупреждение\nс количеством потенциально устаревших модов."
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.TOOLTIPS.MODUPDATER.OPTION_PASSIVE
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.TOOLTIPS.MODUPDATER.OPTION_PASSIVE"
+msgid "Automatically keeps all mods up to date in the background\nby downloading the correct version in the first place."
+msgstr "Автоматически обновляет все моды в фоновом режиме\nзагружая правильную версию в первую очередь."
+

--- a/ModUpdateDate/translations/template.pot
+++ b/ModUpdateDate/translations/template.pot
@@ -43,6 +43,21 @@ msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MAINMENU_UPDA
 msgid "\n\n<color=#FFCC00>1 mod may be out of date</color>"
 msgstr ""
 
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MAINMENU_UPDATING
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MAINMENU_UPDATING"
+msgid "\n\n<color=#00CC00>Auto-Update in progress</color>"
+msgstr ""
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MOD_AUTO_UPDATE
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MOD_AUTO_UPDATE"
+msgid "<b>Automatic updates are enabled.</b>\n"
+msgstr ""
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MOD_ERR_UPDATE
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MOD_ERR_UPDATE"
+msgid "Unable to automatically update this mod!\nA manual update may be required."
+msgstr ""
+
 #. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MOD_OUTDATED
 msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.MOD_OUTDATED"
 msgid "This mod appears to be out of date!"
@@ -71,6 +86,21 @@ msgstr ""
 #. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.OPTION_MAINMENU
 msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.OPTION_MAINMENU"
 msgid "Show Updates in Main Menu"
+msgstr ""
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.OPTION_PASSIVE
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.OPTION_PASSIVE"
+msgid "Auto-Update"
+msgstr ""
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.SAFE_MODE
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.SAFE_MODE"
+msgid "<b>Mod Updater did not start correctly.</b>\n\nDue to a recent Klei update, Mod Updater was unable to start.\nSteam may automatically update Mod Updater to the latest version.\nIf not, install the latest version manually from the mod website.\n\n<b>Mod Updater version:</b> {0}\n<b>Compiled for game version:</b> {1}"
+msgstr ""
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.SAFE_MODE_GITHUB
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.SAFE_MODE_GITHUB"
+msgid "VISIT WEBSITE"
 msgstr ""
 
 #. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.MODUPDATER.STEAM_UPDATE
@@ -176,5 +206,10 @@ msgstr ""
 #. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.TOOLTIPS.MODUPDATER.OPTION_MAINMENU
 msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.TOOLTIPS.MODUPDATER.OPTION_MAINMENU"
 msgid "If selected, a warning with the number of potentially\noutdated mods is shown in the main menu."
+msgstr ""
+
+#. PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.TOOLTIPS.MODUPDATER.OPTION_PASSIVE
+msgctxt "PeterHan.ModUpdateDate.ModUpdateDateStrings.UI.TOOLTIPS.MODUPDATER.OPTION_PASSIVE"
+msgid "Automatically keeps all mods up to date in the background\nby downloading the correct version in the first place."
 msgstr ""
 

--- a/PLibCore/PPatchTools.cs
+++ b/PLibCore/PPatchTools.cs
@@ -275,7 +275,7 @@ namespace PeterHan.PLib.Core {
 		/// <param name="opcodes">The IL instructions to log.</param>
 		public static void DumpMethodBody(TranspiledMethod opcodes) {
 			var result = new StringBuilder(1024);
-			result.Append("METHOD BODY:");
+			result.AppendLine("METHOD BODY:");
 			foreach (var instr in opcodes) {
 				foreach (var block in instr.blocks) {
 					var type = block.blockType;
@@ -411,6 +411,8 @@ namespace PeterHan.PLib.Core {
 			var opcode = load.opcode;
 			if (opcode == OpCodes.Ldloc)
 				instr = new CodeInstruction(OpCodes.Stloc, load.operand);
+			else if (opcode == OpCodes.Ldloc_S)
+				instr = new CodeInstruction(OpCodes.Stloc_S, load.operand);
 			else if (opcode == OpCodes.Ldloc_0)
 				instr = new CodeInstruction(OpCodes.Stloc_0);
 			else if (opcode == OpCodes.Ldloc_1)

--- a/PLibCore/translations/ru.po
+++ b/PLibCore/translations/ru.po
@@ -86,15 +86,30 @@ msgctxt "PeterHan.PLib.Core.PLibStrings.RESTART_REQUIRED"
 msgid "Oxygen Not Included must be restarted for these options to take effect."
 msgstr "Чтобы эти параметры вступили в силу, необходимо перезапустить Oxygen Not Included."
 
+#. PeterHan.PLib.Core.PLibStrings.TOOLTIP_BLUE
+msgctxt "PeterHan.PLib.Core.PLibStrings.TOOLTIP_BLUE"
+msgid "Blue"
+msgstr "Синий"
+
 #. PeterHan.PLib.Core.PLibStrings.TOOLTIP_CANCEL
 msgctxt "PeterHan.PLib.Core.PLibStrings.TOOLTIP_CANCEL"
 msgid "Discard changes."
 msgstr "Отменить изменения."
 
+#. PeterHan.PLib.Core.PLibStrings.TOOLTIP_GREEN
+msgctxt "PeterHan.PLib.Core.PLibStrings.TOOLTIP_GREEN"
+msgid "Green"
+msgstr "Зелёный"
+
 #. PeterHan.PLib.Core.PLibStrings.TOOLTIP_HOMEPAGE
 msgctxt "PeterHan.PLib.Core.PLibStrings.TOOLTIP_HOMEPAGE"
 msgid "Visit the mod's website."
 msgstr "Посетите сайт мода."
+
+#. PeterHan.PLib.Core.PLibStrings.TOOLTIP_HUE
+msgctxt "PeterHan.PLib.Core.PLibStrings.TOOLTIP_HUE"
+msgid "Hue"
+msgstr "Тон"
 
 #. PeterHan.PLib.Core.PLibStrings.TOOLTIP_MANUAL
 msgctxt "PeterHan.PLib.Core.PLibStrings.TOOLTIP_MANUAL"
@@ -116,15 +131,30 @@ msgctxt "PeterHan.PLib.Core.PLibStrings.TOOLTIP_PREVIOUS"
 msgid "Previous"
 msgstr "Предыдущий"
 
+#. PeterHan.PLib.Core.PLibStrings.TOOLTIP_RED
+msgctxt "PeterHan.PLib.Core.PLibStrings.TOOLTIP_RED"
+msgid "Red"
+msgstr "Красный"
+
 #. PeterHan.PLib.Core.PLibStrings.TOOLTIP_RESET
 msgctxt "PeterHan.PLib.Core.PLibStrings.TOOLTIP_RESET"
 msgid "Resets the mod configuration to default values."
 msgstr "Сбросить конфигурацию мода до значений по умолчанию."
 
+#. PeterHan.PLib.Core.PLibStrings.TOOLTIP_SATURATION
+msgctxt "PeterHan.PLib.Core.PLibStrings.TOOLTIP_SATURATION"
+msgid "Saturation"
+msgstr "Насыщенность"
+
 #. PeterHan.PLib.Core.PLibStrings.TOOLTIP_TOGGLE
 msgctxt "PeterHan.PLib.Core.PLibStrings.TOOLTIP_TOGGLE"
 msgid "Show or hide this options category"
 msgstr "Показать или скрыть эту категорию настроек"
+
+#. PeterHan.PLib.Core.PLibStrings.TOOLTIP_VALUE
+msgctxt "PeterHan.PLib.Core.PLibStrings.TOOLTIP_VALUE"
+msgid "Value"
+msgstr "Яркость"
 
 #. PeterHan.PLib.Core.PLibStrings.TOOLTIP_VERSION
 msgctxt "PeterHan.PLib.Core.PLibStrings.TOOLTIP_VERSION"

--- a/PLibCore/translations/template.pot
+++ b/PLibCore/translations/template.pot
@@ -73,14 +73,29 @@ msgctxt "PeterHan.PLib.Core.PLibStrings.RESTART_REQUIRED"
 msgid "Oxygen Not Included must be restarted for these options to take effect."
 msgstr ""
 
+#. PeterHan.PLib.Core.PLibStrings.TOOLTIP_BLUE
+msgctxt "PeterHan.PLib.Core.PLibStrings.TOOLTIP_BLUE"
+msgid "Blue"
+msgstr ""
+
 #. PeterHan.PLib.Core.PLibStrings.TOOLTIP_CANCEL
 msgctxt "PeterHan.PLib.Core.PLibStrings.TOOLTIP_CANCEL"
 msgid "Discard changes."
 msgstr ""
 
+#. PeterHan.PLib.Core.PLibStrings.TOOLTIP_GREEN
+msgctxt "PeterHan.PLib.Core.PLibStrings.TOOLTIP_GREEN"
+msgid "Green"
+msgstr ""
+
 #. PeterHan.PLib.Core.PLibStrings.TOOLTIP_HOMEPAGE
 msgctxt "PeterHan.PLib.Core.PLibStrings.TOOLTIP_HOMEPAGE"
 msgid "Visit the mod's website."
+msgstr ""
+
+#. PeterHan.PLib.Core.PLibStrings.TOOLTIP_HUE
+msgctxt "PeterHan.PLib.Core.PLibStrings.TOOLTIP_HUE"
+msgid "Hue"
 msgstr ""
 
 #. PeterHan.PLib.Core.PLibStrings.TOOLTIP_MANUAL
@@ -103,14 +118,29 @@ msgctxt "PeterHan.PLib.Core.PLibStrings.TOOLTIP_PREVIOUS"
 msgid "Previous"
 msgstr ""
 
+#. PeterHan.PLib.Core.PLibStrings.TOOLTIP_RED
+msgctxt "PeterHan.PLib.Core.PLibStrings.TOOLTIP_RED"
+msgid "Red"
+msgstr ""
+
 #. PeterHan.PLib.Core.PLibStrings.TOOLTIP_RESET
 msgctxt "PeterHan.PLib.Core.PLibStrings.TOOLTIP_RESET"
 msgid "Resets the mod configuration to default values."
 msgstr ""
 
+#. PeterHan.PLib.Core.PLibStrings.TOOLTIP_SATURATION
+msgctxt "PeterHan.PLib.Core.PLibStrings.TOOLTIP_SATURATION"
+msgid "Saturation"
+msgstr ""
+
 #. PeterHan.PLib.Core.PLibStrings.TOOLTIP_TOGGLE
 msgctxt "PeterHan.PLib.Core.PLibStrings.TOOLTIP_TOGGLE"
 msgid "Show or hide this options category"
+msgstr ""
+
+#. PeterHan.PLib.Core.PLibStrings.TOOLTIP_VALUE
+msgctxt "PeterHan.PLib.Core.PLibStrings.TOOLTIP_VALUE"
+msgid "Value"
 msgstr ""
 
 #. PeterHan.PLib.Core.PLibStrings.TOOLTIP_VERSION


### PR DESCRIPTION
- Update russian localization for Plib and Mod Updater.
- in PPatchTools.GetMatchingStoreInstruction was missed the processing of the Ldloc_S instruction.
- in PPatchTools.DumpMethodBody slight change to improve readability.