### PR TITLE
don't log exception backtrace just because directory's not found

### DIFF
--- a/PLibOptions/POptions.cs
+++ b/PLibOptions/POptions.cs
@@ -152,6 +152,11 @@ namespace PeterHan.PLib.Options {
 				PUtil.LogDebug("{0} was not found; using default settings".F(Path.GetFileName(
 					path)));
 #endif
+			} catch (DirectoryNotFoundException) {
+#if DEBUG
+				PUtil.LogDebug("{0} was not found; using default settings".F(Path.GetFileName(
+					path)));
+#endif
 			} catch (UnauthorizedAccessException e) {
 				// Options will be set to defaults
 				PUtil.LogExcWarn(e);


### PR DESCRIPTION
The same handling as FileNotFoundException. I get this on Linux if a mod's settings have never been changed.
