### PR TITLE
SandboxTools

### DIFF
--- a/SandboxTools/SandboxTools.csproj
+++ b/SandboxTools/SandboxTools.csproj
@@ -2,10 +2,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyTitle>Sandbox Tools</AssemblyTitle>
-    <FileVersion>3.8.0.0</FileVersion>
+    <FileVersion>3.8.1.0</FileVersion>
     <RootNamespace>PeterHan.SandboxTools</RootNamespace>
     <Description>Improves the Sandbox Mode tools with numerous small tweaks.</Description>
-    <AssemblyVersion>3.1.0.0</AssemblyVersion>
+    <AssemblyVersion>3.1.1.0</AssemblyVersion>
     <LastWorkingBuild>493472</LastWorkingBuild>
     <Platforms>Vanilla;Mergedown</Platforms>
   </PropertyGroup>

--- a/SandboxTools/SandboxToolsPatches.cs
+++ b/SandboxTools/SandboxToolsPatches.cs
@@ -77,13 +77,13 @@ namespace PeterHan.SandboxTools {
 			filters.Add(new SearchFilter(SandboxToolsStrings.FILTER_GEYSERS,
 				(entity) => {
 					var prefab = entity as KPrefabID;
-					return prefab != null && ((prefab.TryGetComponent(out Geyser _) && prefab.TryGetComponent(out Uncoverable _))
-					|| prefab.PrefabTag.Name == OilWellConfig.ID);
+					return prefab != null && ((prefab.TryGetComponent(out Geyser _) && prefab.TryGetComponent(out Uncoverable _)) ||
+						prefab.PrefabTag.Name == OilWellConfig.ID);
 				}, null, Def.GetUISprite(Assets.GetPrefab("GeyserGeneric_slush_water"))));
 			// Rover
-			if (DlcManager.IsExpansion1Active()) {
-				var rover_name = GameTags.Robots.Models.ScoutRover.Name.ToUpper();
-				var icon = new Tuple<Sprite, Color>(CodexCache.entries[rover_name].icon, CodexCache.entries[rover_name].iconColor);
+			if (DlcManager.IsExpansion1Active() && CodexCache.entries != null &&
+					CodexCache.entries.TryGetValue(GameTags.Robots.Models.ScoutRover.Name.ToUpperInvariant(), out var entry) && entry != null) {
+				var icon = new Tuple<Sprite, Color>(entry.icon, entry.iconColor);
 				var creature_filter = filters.Find(filter => filter.Name == STRINGS.UI.SANDBOXTOOLS.FILTERS.ENTITIES.CREATURE);
 				filters.Add(new SearchFilter(STRINGS.CREATURES.FAMILY_PLURAL.SCOUTROVER,
 					(entity) => {

--- a/SandboxTools/SandboxToolsPatches.cs
+++ b/SandboxTools/SandboxToolsPatches.cs
@@ -81,14 +81,16 @@ namespace PeterHan.SandboxTools {
 					|| prefab.PrefabTag.Name == OilWellConfig.ID);
 				}, null, Def.GetUISprite(Assets.GetPrefab("GeyserGeneric_slush_water"))));
 			// Rover
-			var rover_name = GameTags.Robots.Models.ScoutRover.Name.ToUpper();
-			var icon = new Tuple<Sprite, Color>(CodexCache.entries[rover_name].icon, CodexCache.entries[rover_name].iconColor);
-			var creature_filter = filters.Find(filter => filter.Name == STRINGS.UI.SANDBOXTOOLS.FILTERS.ENTITIES.CREATURE);
-			filters.Add(new SearchFilter(STRINGS.CREATURES.FAMILY_PLURAL.SCOUTROVER,
-				(entity) => {
-					var prefab = entity as KPrefabID;
-					return prefab != null && prefab.PrefabTag.Name == ScoutRoverConfig.ID;
-				}, creature_filter, icon));
+			if (DlcManager.IsExpansion1Active()) {
+				var rover_name = GameTags.Robots.Models.ScoutRover.Name.ToUpper();
+				var icon = new Tuple<Sprite, Color>(CodexCache.entries[rover_name].icon, CodexCache.entries[rover_name].iconColor);
+				var creature_filter = filters.Find(filter => filter.Name == STRINGS.UI.SANDBOXTOOLS.FILTERS.ENTITIES.CREATURE);
+				filters.Add(new SearchFilter(STRINGS.CREATURES.FAMILY_PLURAL.SCOUTROVER,
+					(entity) => {
+						var prefab = entity as KPrefabID;
+						return prefab != null && prefab.PrefabTag.Name == ScoutRoverConfig.ID;
+					}, creature_filter, icon));
+			}
 			// Add matching assets
 			var options = ListPool<object, SandboxToolParameterMenu>.Allocate();
 			foreach (var prefab in Assets.Prefabs)

--- a/SandboxTools/SandboxToolsPatches.cs
+++ b/SandboxTools/SandboxToolsPatches.cs
@@ -24,6 +24,7 @@ using PeterHan.PLib.Database;
 using PeterHan.PLib.PatchManager;
 using System;
 using System.Collections.Generic;
+using UnityEngine;
 
 using SearchFilter = SandboxToolParameterMenu.SelectorValue.SearchFilter;
 
@@ -76,9 +77,18 @@ namespace PeterHan.SandboxTools {
 			filters.Add(new SearchFilter(SandboxToolsStrings.FILTER_GEYSERS,
 				(entity) => {
 					var prefab = entity as KPrefabID;
-					return prefab != null && (prefab.TryGetComponent(out Geyser _) || prefab.
-						PrefabTag.Name == OilWellConfig.ID);
+					return prefab != null && ((prefab.TryGetComponent(out Geyser _) && prefab.TryGetComponent(out Uncoverable _))
+					|| prefab.PrefabTag.Name == OilWellConfig.ID);
 				}, null, Def.GetUISprite(Assets.GetPrefab("GeyserGeneric_slush_water"))));
+			// Rover
+			var rover_name = GameTags.Robots.Models.ScoutRover.Name.ToUpper();
+			var icon = new Tuple<Sprite, Color>(CodexCache.entries[rover_name].icon, CodexCache.entries[rover_name].iconColor);
+			var creature_filter = filters.Find(filter => filter.Name == STRINGS.UI.SANDBOXTOOLS.FILTERS.ENTITIES.CREATURE);
+			filters.Add(new SearchFilter(STRINGS.CREATURES.FAMILY_PLURAL.SCOUTROVER,
+				(entity) => {
+					var prefab = entity as KPrefabID;
+					return prefab != null && prefab.PrefabTag.Name == ScoutRoverConfig.ID;
+				}, creature_filter, icon));
 			// Add matching assets
 			var options = ListPool<object, SandboxToolParameterMenu>.Allocate();
 			foreach (var prefab in Assets.Prefabs)


### PR DESCRIPTION
1. added Rover to SandboxSpawnerTool.
2. removed old early-access geysers (Steam, Natural Gas, Chlorine), they cause a crash when clicking on the Geotuner, since the necessary Uncoverable component is missing.