### PR TITLE
reduce idle movement of dupes/critters that are not visible

### DIFF
--- a/FastTrack/FastTrackOptions.cs
+++ b/FastTrack/FastTrackOptions.cs
@@ -100,6 +100,10 @@ namespace PeterHan.FastTrack {
 		[JsonProperty]
 		public bool UnstackLights { get; set; }
 
+		[Option("STRINGS.UI.FRONTEND.FASTTRACK.REDUCECRITTERIDLEMOVE", "STRINGS.UI.TOOLTIPS.FASTTRACK.REDUCECRITTERIDLEMOVE", "STRINGS.UI.FRONTEND.FASTTRACK.CATEGORY_CRITTERS")]
+		[JsonProperty]
+		public bool ReduceCritterIdleMove { get; set; }
+
 		[Option("STRINGS.UI.FRONTEND.FASTTRACK.FASTATTRIBUTESMODE", "STRINGS.UI.TOOLTIPS.FASTTRACK.FASTATTRIBUTESMODE", "STRINGS.UI.FRONTEND.FASTTRACK.CATEGORY_DUPLICANTS")]
 		[JsonProperty]
 		public bool FastAttributesMode { get; set; }
@@ -131,6 +135,10 @@ namespace PeterHan.FastTrack {
 		[Option("STRINGS.UI.FRONTEND.FASTTRACK.SENSOROPTS", "STRINGS.UI.TOOLTIPS.FASTTRACK.SENSOROPTS", "STRINGS.UI.FRONTEND.FASTTRACK.CATEGORY_DUPLICANTS")]
 		[JsonProperty]
 		public bool SensorOpts { get; set; }
+
+		[Option("STRINGS.UI.FRONTEND.FASTTRACK.REDUCEDUPLICANTIDLEMOVE", "STRINGS.UI.TOOLTIPS.FASTTRACK.REDUCEDUPLICANTIDLEMOVE", "STRINGS.UI.FRONTEND.FASTTRACK.CATEGORY_DUPLICANTS")]
+		[JsonProperty]
+		public bool ReduceDuplicantIdleMove { get; set; }
 
 		[Option("STRINGS.UI.FRONTEND.FASTTRACK.REDUCECOLONYTRACKING", "STRINGS.UI.TOOLTIPS.FASTTRACK.REDUCECOLONYTRACKING", "STRINGS.UI.FRONTEND.FASTTRACK.CATEGORY_INTERFACE")]
 		[JsonProperty]
@@ -300,6 +308,8 @@ namespace PeterHan.FastTrack {
 			PickupOpts = true;
 			RadiationOpts = true;
 			ReduceColonyTracking = false;
+			ReduceCritterIdleMove = true;
+			ReduceDuplicantIdleMove = true;
 			ReduceSoundUpdates = true;
 			ReduceTileUpdates = true;
 			RenderTicks = true;

--- a/FastTrack/FastTrackStrings.cs
+++ b/FastTrack/FastTrackStrings.cs
@@ -52,6 +52,7 @@ namespace PeterHan.FastTrack {
 					public static LocString THREATOVERCROWDING = "Critter Monitors";
 					public static LocString CRITTERCONSUMERS = "Optimize Eating";
 					public static LocString UNSTACKLIGHTS = "Unstack Lights";
+					public static LocString REDUCECRITTERIDLEMOVE = "Reduce Idle Movement";
 
 					public static LocString FASTATTRIBUTESMODE = "Attribute Leveling";
 					public static LocString ASYNCPATHPROBE = "Background Pathing";
@@ -61,6 +62,7 @@ namespace PeterHan.FastTrack {
 					public static LocString NODISEASE = "Disable Disease";
 					public static LocString FASTREACHABILITY = "Fast Reachability Checks";
 					public static LocString SENSOROPTS = "Optimize Idling";
+					public static LocString REDUCEDUPLICANTIDLEMOVE = "Reduce Idle Movement";
 
 					public static LocString REDUCECOLONYTRACKING = "Colony Tracker Reduction";
 					public static LocString DISABLEACHIEVEMENTS = "Disable Achievements";
@@ -137,6 +139,7 @@ namespace PeterHan.FastTrack {
 					public static LocString THREATOVERCROWDING = "Optimizes critter Threat and Overcrowding monitors.\n<i>May conflict with mods that add new critters</i>" + PERF_MEDIUM;
 					public static LocString CRITTERCONSUMERS = "Optimize how Critters find objects to eat." + PERF_LOW;
 					public static LocString UNSTACKLIGHTS = "Reduces the visual effects shown when many light sources are stacked.\nIntended for ranching critters like Shine Bugs." + PERF_LOW;
+					public static LocString REDUCECRITTERIDLEMOVE = "Reduces amount of idle movement of critters that are currently not visible on the screen." + PERF_LOW;
 
 					public static LocString FASTATTRIBUTESMODE = "Optimize attribute leveling and work efficiency calculation." + PERF_MEDIUM;
 					public static LocString ASYNCPATHPROBE = "Moves some pathfinding calculations to a non-blocking thread." + PERF_HIGH;
@@ -151,6 +154,7 @@ namespace PeterHan.FastTrack {
 						"<i>Not compatible with mods: Diseases Restored, Diseases Expanded</i>" + PERF_MEDIUM;
 					public static LocString FASTREACHABILITY = "Only check items and chores for reachability when necessary." + PERF_MEDIUM;
 					public static LocString SENSOROPTS = "Only check for locations to Idle, Mingle, or Balloon Artist when necessary." + PERF_LOW;
+					public static LocString REDUCEDUPLICANTIDLEMOVE = "Reduces amount of idle movement of duplicants that are currently not visible on the screen." + PERF_LOW;
 
 					public static LocString REDUCECOLONYTRACKING = "Reduces the update rate of Colony Diagnostics.\n<i>Some notifications may take longer to trigger</i>" + PERF_LOW;
 					public static LocString DISABLEACHIEVEMENTS = "Turn off checking for Colony Initiatives.\n<color=#FF0000>Disabling will prevent unlocking any Steam achievement</color>" + PERF_LOW;

--- a/FastTrack/PathPatches/IdleMove.cs
+++ b/FastTrack/PathPatches/IdleMove.cs
@@ -1,0 +1,86 @@
+﻿/*
+ * Copyright 2023 Peter Han
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+using HarmonyLib;
+
+namespace PeterHan.FastTrack.PathPatches {
+	/// <summary>
+	/// Prevent idle duplicants that cannot be seen at the moment from moving idly 95% of the time.
+	/// </summary>
+	[HarmonyPatch(typeof(IdleChore.States), nameof(IdleChore.States.InitializeStates))]
+	public static class IdleChore_States_InitializeStates_Patch {
+		internal static bool Prepare() => FastTrackOptions.Instance.ReduceDuplicantIdleMove;
+
+		/// <summary>
+		/// When the move state is entered, go to the idle state again if the duplicant
+		/// is not visible (95% of cases).
+		/// </summary>
+		internal static void Postfix(IdleChore.States __instance) {
+			__instance.idle.move.Enter( delegate( IdleChore.StatesInstance smi )
+				{
+					if( GridVisibleArea.GetVisibleArea().Contains( Grid.PosToCell( smi )))
+						return;
+					if( UnityEngine.Random.Range( 1, 100 ) <= 5 )
+						return;
+					smi.GoTo( smi.sm.idle );
+				});
+		}
+	}
+
+	/// <summary>
+	/// Prevent idle critters that cannot be seen at the moment from moving idly 95% of the time.
+	/// </summary>
+	[HarmonyPatch(typeof(IdleStates), nameof(IdleStates.MoveToNewCell))]
+	public static class IdleStates_MoveToNewCell_Patch {
+		internal static bool Prepare() => FastTrackOptions.Instance.ReduceCritterIdleMove;
+
+		/// <summary>
+		/// Called when the move state is entered, go to the loop (=idle) state again if critter
+		/// is not visible (95% of cases).
+		/// </summary>
+		internal static bool Prefix(IdleStates.Instance smi, IdleStates.State ___loop ) {
+			if( GridVisibleArea.GetVisibleArea().Contains( Grid.PosToCell( smi )))
+				return true;
+			if( UnityEngine.Random.Range( 1, 100 ) <= 5 )
+				return true;
+			smi.GoTo( ___loop );
+			return false;
+		}
+	}
+
+	/// <summary>
+	/// Prevent bees that cannot be seen at the moment from moving idly 95% of the time.
+	/// </summary>
+	[HarmonyPatch(typeof(BuzzStates), nameof(BuzzStates.MoveToNewCell))]
+	public static class BuzzStates_MoveToNewCell_Patch {
+		internal static bool Prepare() => FastTrackOptions.Instance.ReduceCritterIdleMove;
+
+		/// <summary>
+		/// Called when the move state is entered, go to the idle state again if bee
+		/// is not visible (95% of cases).
+		/// </summary>
+		internal static bool Prefix(BuzzStates.Instance smi ) {
+			if( GridVisibleArea.GetVisibleArea().Contains( Grid.PosToCell( smi )))
+				return true;
+			if( UnityEngine.Random.Range( 1, 100 ) <= 5 )
+				return true;
+			smi.GoTo( smi.sm.idle );
+			return false;
+		}
+	}
+}


### PR DESCRIPTION
Reduces cost shown by metrics in Navigator+StatesInstance, called every tick. The actual code is TrasitionDriver.UpdateTransition(), taking care of moving dupes/critters. Since moving idle dupes/critters is mostly pointless if they are not visible, avoid that 95% of the time. Still leave those 5% for the cases when wandering around may matter, e.g. with some critter contraptions.

Reduces time spent in Navigator+StatesInstance from ~40ms to ~25 ms here ([noidlemove.zip](https://github.com/peterhaneve/ONIMods/files/12139103/noidlemove.zip)).

Note: Getting FastTrack to build on Linux was a huge pain, and when I finally managed somehow the game crashed with it while starting for some cryptic reason (fatal parse error), at which point I gave up. The code works as a part of my mod, the patch compiles, but I couldn't get to test the patch itself. I suggest checking the config UI, just in case I missed something there.
