### PR TITLE
fix food tooltip for e.g. bountiful mutation

### DIFF
--- a/FoodTooltip/FoodTooltipUtils.cs
+++ b/FoodTooltip/FoodTooltipUtils.cs
@@ -20,6 +20,7 @@ using PeterHan.PLib.Core;
 using System;
 using System.Collections.Generic;
 using UnityEngine;
+using Klei.AI;
 
 using TimeSlice = GameUtil.TimeSlice;
 
@@ -40,11 +41,14 @@ namespace PeterHan.FoodTooltip {
 		/// <param name="descriptors">The location where the descriptors should be placed.</param>
 		internal static void AddCropDescriptors(Crop crop, IList<Descriptor> descriptors) {
 			var cropVal = crop.cropVal;
+			GameObject go = crop.gameObject;
+			Klei.AI.Attribute yieldAmount = Db.Get().PlantAttributes.YieldAmount;
+			float preModifiedAttributeValue = go.GetComponent<Modifiers>().GetPreModifiedAttributeValue(yieldAmount);
 			var maturity = Db.Get().Amounts.Maturity.Lookup(crop.gameObject);
 			if (maturity != null)
 				CreateDescriptors(TagManager.Create(cropVal.cropId), descriptors,
-					maturity.GetDelta() * Constants.SECONDS_PER_CYCLE * cropVal.numProduced /
-					maturity.GetMax(), FoodDescriptorTexts.PLANTS);
+					maturity.GetDelta() * Constants.SECONDS_PER_CYCLE * cropVal.numProduced
+					* preModifiedAttributeValue / maturity.GetMax(), FoodDescriptorTexts.PLANTS);
 		}
 
 		/// <summary>


### PR DESCRIPTION
Without this, the food supply tooltip shows the calories rate of an original plant, but it should show double because of the double yield amount. See also Crop.InformationDescriptors().

[test - mutants.sav.zip](https://github.com/peterhaneve/ONIMods/files/14736201/test.-.mutants.sav.zip)

Also, what is the status of #443 ? It's same like when I submitted it the first time. If you do not want it, just say so.

