### PR TITLE
Fast Track: Fix target method name for `OpenCodexEntry_Patch`

### DIFF
--- a/FastTrack/UIPatches/DetailsPanelWrapper.cs
+++ b/FastTrack/UIPatches/DetailsPanelWrapper.cs
@@ -361,7 +361,7 @@ namespace PeterHan.FastTrack.UIPatches {
 		/// <summary>
 		/// Applied to DetailsScreen to make opening the codex entry much faster!
 		/// </summary>
-		[HarmonyPatch(typeof(DetailsScreen), nameof(DetailsScreen.OpenCodexEntry))]
+		[HarmonyPatch(typeof(DetailsScreen), nameof(DetailsScreen.CodexEntryButton_OnClick))]
 		internal static class OpenCodexEntry_Patch {
 			internal static bool Prepare() => FastTrackOptions.Instance.SideScreenOpts;
 


### PR DESCRIPTION
The `OpenCodexEntry` method of the `DetailsScreen` class seems to have been renamed to `CodexEntryButton_OnClick` for some reason. Update the `HarmonyPatch` annotation to use the new method name.

Tested on U52-622509 with both Spaced Out! and Frosty Planet DLCs, the game now loads without crashing. Also, Fast Track itself seems to work properly, with various other mods (including True Tiles).