### PR TITLE
typo fixed + later CreateLocStringKeys

### DIFF
--- a/ForbidItems/ForbidItemsPatches.cs
+++ b/ForbidItems/ForbidItemsPatches.cs
@@ -33,6 +33,8 @@ namespace PeterHan.ForbidItems {
 		
 		[PLibMethod(RunAt.AfterDbInit)]
 		internal static void AfterDbInit() {
+			LocString.CreateLocStringKeys(typeof(ForbidItemsStrings.MISC));
+			LocString.CreateLocStringKeys(typeof(ForbidItemsStrings.UI));
 			ForbiddenStatus = Db.Get().MiscStatusItems.Add(new StatusItem(Forbidden.Name,
 				"MISC", "status_item_building_disabled", StatusItem.IconType.Custom,
 				NotificationType.Neutral, false, OverlayModes.None.ID));
@@ -42,8 +44,6 @@ namespace PeterHan.ForbidItems {
 			base.OnLoad(harmony);
 			PUtil.InitLibrary();
 			new PPatchManager(harmony).RegisterPatchClass(typeof(ForbidItemsPatches));
-			LocString.CreateLocStringKeys(typeof(ForbidItemsStrings.MISC));
-			LocString.CreateLocStringKeys(typeof(ForbidItemsStrings.UI));
 			new PLocalization().Register();
 		}
 

--- a/ForbidItems/translations/template.pot
+++ b/ForbidItems/translations/template.pot
@@ -1,46 +1,35 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: \n"
-"POT-Creation-Date: \n"
-"PO-Revision-Date: \n"
-"Last-Translator: DarkEviL88\n"
-"Language-Team: \n"
-"Language: ru_RU\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
-"Application: Oxygen Not IncludedPOT Version: 2.0\n"
-"X-Generator: Poedit 3.4.2\n"
+"Application: Oxygen Not Included"
+"POT Version: 2.0"
 
 #. PeterHan.ForbidItems.ForbidItemsStrings.MISC.STATUSITEMS.FORBIDDEN.NAME
 msgctxt "PeterHan.ForbidItems.ForbidItemsStrings.MISC.STATUSITEMS.FORBIDDEN.NAME"
 msgid "Item Forbidden"
-msgstr "Предмет запрещён"
+msgstr ""
 
 #. PeterHan.ForbidItems.ForbidItemsStrings.MISC.STATUSITEMS.FORBIDDEN.TOOLTIP
 msgctxt "PeterHan.ForbidItems.ForbidItemsStrings.MISC.STATUSITEMS.FORBIDDEN.TOOLTIP"
 msgid "This item cannot be picked up by Duplicants or <style=\"KKeyword\">Auto-Sweepers</style>"
-msgstr "Дубликанты и <style=\"KKeyword\">автосборщики</style> не могут подобрать этот предмет"
+msgstr ""
 
 #. PeterHan.ForbidItems.ForbidItemsStrings.UI.USERMENUACTIONS.FORBIDITEM.NAME
 msgctxt "PeterHan.ForbidItems.ForbidItemsStrings.UI.USERMENUACTIONS.FORBIDITEM.NAME"
 msgid "Forbid Item"
-msgstr "Запретить предмет"
+msgstr ""
 
 #. PeterHan.ForbidItems.ForbidItemsStrings.UI.USERMENUACTIONS.FORBIDITEM.NAME_OFF
 msgctxt "PeterHan.ForbidItems.ForbidItemsStrings.UI.USERMENUACTIONS.FORBIDITEM.NAME_OFF"
 msgid "Reclaim Item"
-msgstr "Разрешить предмет"
+msgstr ""
 
 #. PeterHan.ForbidItems.ForbidItemsStrings.UI.USERMENUACTIONS.FORBIDITEM.TOOLTIP
 msgctxt "PeterHan.ForbidItems.ForbidItemsStrings.UI.USERMENUACTIONS.FORBIDITEM.TOOLTIP"
 msgid "Prevent this item from being picked up"
-msgstr "Запретить подбирать этот предмет"
+msgstr ""
 
 #. PeterHan.ForbidItems.ForbidItemsStrings.UI.USERMENUACTIONS.FORBIDITEM.TOOLTIP_OFF
 msgctxt "PeterHan.ForbidItems.ForbidItemsStrings.UI.USERMENUACTIONS.FORBIDITEM.TOOLTIP_OFF"
 msgid "Allow this item to be picked up"
-msgstr "Разрешить подбирать этот предмет"
+msgstr ""
 


### PR DESCRIPTION
it is better to create the LocStringKeys later than the localization is actually loaded.
otherwise it happens
![457140_20240722102909_2](https://github.com/user-attachments/assets/83c3aa97-8591-435c-87b8-bfac917b2ef4)
