### PR TITLE
more PPatchManager patches

### DIFF
--- a/PLibCore/PatchManager/PPatchManager.cs
+++ b/PLibCore/PatchManager/PPatchManager.cs
@@ -72,6 +72,14 @@ namespace PeterHan.PLib.PatchManager {
 			Instance?.InvokeAllProcess(RunAt.AfterDbInit, null);
 		}
 
+		private static void PostProcess_Prefix() {
+			Instance?.InvokeAllProcess(RunAt.BeforeDbPostProcess, null);
+		}
+
+		private static void PostProcess_Postfix() {
+			Instance?.InvokeAllProcess(RunAt.AfterDbPostProcess, null);
+		}
+
 		private static void Instance_Postfix() {
 			bool load = false;
 			if (Instance != null)
@@ -85,6 +93,10 @@ namespace PeterHan.PLib.PatchManager {
 
 		private static void MainMenu_OnSpawn_Postfix() {
 			Instance?.InvokeAllProcess(RunAt.InMainMenu, null);
+		}
+
+		private static void DetailsScreen_OnPrefabInit_Postfix() {
+			Instance?.InvokeAllProcess(RunAt.OnDetailsScreenInit, null);
 		}
 
 		public override Version Version => VERSION;
@@ -147,7 +159,7 @@ namespace PeterHan.PLib.PatchManager {
 					GetNameSafe());
 			}
 			this.harmony = harmony;
-			patches = new Dictionary<uint, PrivateRunList>(8);
+			patches = new Dictionary<uint, PrivateRunList>(11);
 			InstanceData = patches;
 		}
 
@@ -168,6 +180,8 @@ namespace PeterHan.PLib.PatchManager {
 			// Db
 			plibInstance.Patch(typeof(Db), nameof(Db.Initialize), prefix: PatchMethod(nameof(
 				Initialize_Prefix)), postfix: PatchMethod(nameof(Initialize_Postfix)));
+			plibInstance.Patch(typeof(Db), nameof(Db.PostProcess), prefix: PatchMethod(nameof(
+				PostProcess_Prefix)), postfix: PatchMethod(nameof(PostProcess_Postfix)));
 
 			// Game
 			plibInstance.Patch(typeof(Game), "DestroyInstances", postfix: PatchMethod(nameof(
@@ -182,6 +196,10 @@ namespace PeterHan.PLib.PatchManager {
 			// MainMenu
 			plibInstance.Patch(typeof(MainMenu), "OnSpawn", postfix: PatchMethod(
 				nameof(MainMenu_OnSpawn_Postfix)));
+
+			// DetailsScreen
+			plibInstance.Patch(typeof(DetailsScreen), "OnPrefabInit", postfix: PatchMethod(
+				nameof(DetailsScreen_OnPrefabInit_Postfix)));
 		}
 
 		public override void PostInitialize(Harmony plibInstance) {

--- a/PLibCore/PatchManager/RunAt.cs
+++ b/PLibCore/PatchManager/RunAt.cs
@@ -73,6 +73,21 @@ namespace PeterHan.PLib.PatchManager {
 		public const uint AfterLayerableLoad = 7U;
 
 		/// <summary>
+		/// Runs immediately before Db.PostProcess.
+		/// </summary>
+		public const uint BeforeDbPostProcess = 8U;
+
+		/// <summary>
+		/// Runs immediately after Db.PostProcess.
+		/// </summary>
+		public const uint AfterDbPostProcess = 9U;
+
+		/// <summary>
+		/// Runs when DetailsScreen.OnPrefabInit has completed.
+		/// </summary>
+		public const uint OnDetailsScreenInit = 10U;
+
+		/// <summary>
 		/// The string equivalents of each constant for debugging.
 		/// </summary>
 		private static readonly string[] STRING_VALUES = new string[] {


### PR DESCRIPTION
DetailsScreen.OnPrefabInit - for the purpose of comfortable registration custom SideScreenContents.
Db.PostProcess - just a convenient entry point when need to do some manipulations, after all buildings, entities, etc prefabs have been created