### PR TITLE
Build with `dotnet` tools for both .NETFramework and .NETStandard.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,17 +14,15 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup Condition=" '$(UsePublicized)' == 'true' " >
-    <PubliciseInputAssemblies Include="$(GameFolder)/Assembly-CSharp.dll;
-      $(GameFolder)/Assembly-CSharp-firstpass.dll"/>
-    <Reference Include="Assembly-CSharp_public" HintPath="../public-lib/Assembly-CSharp_public.dll" />
-    <Reference Include="Assembly-CSharp-firstpass_public" HintPath="../public-lib/Assembly-CSharp-firstpass_public.dll" />
-    <PackageReference Include="Aze.Publicise.MSBuild.Task" Version="1.1.0"/>
-  </ItemGroup>
-  <ItemGroup Condition=" '$(UsePublicized)' != 'true' " >
-    <Reference Include="Assembly-CSharp" HintPath="$(GameFolder)/Assembly-CSharp.dll" />
-    <Reference Include="Assembly-CSharp-firstpass" HintPath="$(GameFolder)/Assembly-CSharp-firstpass.dll" />
+    <PackageReference Include="Krafs.Publicizer" Version="2.3.0">
+      <PrivateAssets>all</PrivateAssets>
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
+    <Publicize Include="Assembly-CSharp;Assembly-CSharp-firstpass" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="Assembly-CSharp" HintPath="$(GameFolder)/Assembly-CSharp.dll" />
+    <Reference Include="Assembly-CSharp-firstpass" HintPath="$(GameFolder)/Assembly-CSharp-firstpass.dll" />
     <Reference Include="0Harmony" HintPath="$(GameFolder)/0Harmony.dll" />
     <Reference Include="FMODUnity" HintPath="$(GameFolder)/FMODUnity.dll" />
     <Reference Include="Newtonsoft.Json" HintPath="$(GameFolder)/Newtonsoft.Json.dll" />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -6,10 +6,6 @@
     </PropertyGroup>
   </Target>
 
-  <Target Name="Publicize" AfterTargets="Clean" Condition=" '$(UsePublicized)' == 'true' ">
-    <Publicise InputAssemblies="@(PubliciseInputAssemblies)" OutputPath="../public-lib/"/>
-  </Target>
-
   <Target Name="GenerateRefAssemblies" AfterTargets="Clean" Condition=" '$(MSBuildProjectName)' == 'PLib' And '$(GameFolder)' != '../Lib' ">
     <Exec Command="Refasmer -v -O ../Lib --all -c ../public-lib/Assembly-CSharp_public.dll ../public-lib/Assembly-CSharp-firstpass_public.dll ^
     $(GameFolder)/Assembly-CSharp.dll $(GameFolder)/Assembly-CSharp-firstpass.dll $(GameFolder)/0Harmony.dll ^
@@ -81,7 +77,6 @@ staticID: PeterHan.$(AssemblyName)
     </ItemGroup>
 
     <ILRepack
-        TargetPlatformVersion="v4"
         TargetKind="SameAsPrimaryAssembly"
         OutputFile="$(TargetPath)"
         InputAssemblies="@(InputAssemblies)"


### PR DESCRIPTION
To support building for .NETStandard in GH-605, this PR configures build tools to support builds with .NETStandard (and `dotnet` tools). Two distinct tools are changed: the **Publicizer** and **ILRepack**.

For Publicizer, we replace Aze.Publicise.MSBuild.Task/1.1.0 with Krafs.Publicizer/2.3.0 as per recommendation by the author (Aze).

> [!NOTE]
> For consumers that prefer to use Aze.Publicise.MSBuild.Task, PR AzeTheGreat/Publicise#1 is available for a working patch. However, approval is pending (possibly indefinitely).

For ILRepack, we use automatic configuration for attribute 'TargetPlatformVersion' now that previous bugs have been fixed.