### PR TITLE
Incremental repack

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
+  <PropertyGroup Condition=" '$(PLibCore)' != 'true' ">
+    <SkipCopyBuildProduct>true</SkipCopyBuildProduct>
+    <ClearOutputDirectory>false</ClearOutputDirectory>
+  </PropertyGroup>
+
   <Target Name="SetPlatform" BeforeTargets="CoreCompile">
     <PropertyGroup>
       <PlatformTarget>AnyCPU</PlatformTarget>
@@ -61,20 +66,33 @@ staticID: PeterHan.$(AssemblyName)
     <WriteLinesToFile File="$(ModDescriptionFile)" Overwrite="true" Lines="$(ModDescriptionFileContent)"/>
   </Target>
 
-  <Target Name="ILRepack" AfterTargets="Build" Condition=" '$(PLibCore)' != 'true' and '$(TargetFramework)' != '' ">
-    <PropertyGroup Condition=" '$(AssemblyName)' == 'PLib' ">
-      <Internalize>false</Internalize>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(AssemblyName)' != 'PLib' ">
-      <Internalize>true</Internalize>
-    </PropertyGroup>
+  <Target Name="_GetRepackInputs">
+    <ItemGroup>
+      <!-- Since ILRepack outputs to 'bin/ASSEMBLY_NAME.dll', use the intermediate assembly in 'obj/ASSEMBLY_NAME.dll' as input. -->
+      <InputAssemblies Include="@(IntermediateAssembly)"/>
+    </ItemGroup>
     <ItemGroup Condition=" '$(UsesPLib)' != 'false' Or '$(AssemblyName)' == 'PLib' ">
-      <InputAssemblies Include="$(TargetPath)" />
-      <InputAssemblies Include="$(TargetDir)PLib*.dll" />
+      <!-- Use referenced PLib assemblies before they are copied to 'bin' by matching their filename to the glob 'PLib*.dll'. -->
+      <InputAssemblies
+        Include="@(ReferenceCopyLocalPaths->WithMetadataValue('Extension', '.dll'))"
+        Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('%(Filename)', '^PLib'))"/>
     </ItemGroup>
-    <ItemGroup Condition=" '$(UsesPLib)' == 'false' ">
-      <InputAssemblies Include="$(TargetPath)" />
-    </ItemGroup>
+  </Target>
+
+  <Target
+    Name="ILRepack"
+    DependsOnTargets="_GetRepackInputs"
+    AfterTargets="PrepareForRun"
+    Inputs="@(InputAssemblies)"
+    Outputs="$(TargetPath)"
+    Condition=" '$(PLibCore)' != 'true' ">
+    <Warning
+      Text="ILRepack will clobber redundant output. To suppress redundant output, configure CopyBuildOutputToOutputDirectory='false' or SkipCopyBuildProduct='true'."
+      Condition="'$(CopyBuildOutputToOutputDirectory)' == 'true' And '$(SkipCopyBuildProduct)' != 'true'"/>
+
+    <PropertyGroup>
+      <Internalize>$('$(AssemblyName)' == 'PLib')</Internalize>
+    </PropertyGroup>
 
     <ILRepack
         TargetKind="SameAsPrimaryAssembly"
@@ -84,9 +102,15 @@ staticID: PeterHan.$(AssemblyName)
         Internalize="$(Internalize)"
         Wildcards="true"
         LibraryPath="$(GameFolder)" />
+
+    <!-- Notify MSBuild of files output by ILRepack to support targets 'Clean' and 'IncrementalClean'. -->
+    <ItemGroup>
+      <FileWrites Include="$(TargetPath)" Condition="Exists('$(TargetPath)')"/>
+      <FileWrites Include="$(OutputPath)$(AssemblyName).xml" Condition="Exists('$(OutputPath)$(AssemblyName).xml')"/>
+    </ItemGroup>
   </Target>
 
-  <Target Name="CopyArtifactsToInstallFolder" AfterTargets="ILRepack" Condition=" '$(DistributeMod)' == 'true' and '$(TargetFramework)' != '' ">
+  <Target Name="CopyArtifactsToInstallFolder" AfterTargets="ILRepack" Condition=" '$(DistributeMod)' == 'true' ">
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
       <RootInstallFolder>..\Release\$(ProjectName)</RootInstallFolder>
     </PropertyGroup>

--- a/FastTrack/FastTrack.csproj
+++ b/FastTrack/FastTrack.csproj
@@ -22,7 +22,7 @@ namespace PeterHan.FastTrack {
     <SupportedContent></SupportedContent>
   </PropertyGroup>
   <Target Name="WriteModVersionFile" BeforeTargets="PreBuildEvent">
-    <WriteLinesToFile File="$(IntermediateOutputPath)\Version.cs" Overwrite="true" Lines="$(VersionFileContent)" />
+    <WriteLinesToFile File="$(IntermediateOutputPath)\Version.cs" Overwrite="true" WriteOnlyWhenDifferent="true" Lines="$(VersionFileContent)" />
   </Target>
   <ItemGroup>
     <None Remove="images/*.png" />

--- a/ModUpdateDate/ModUpdateDate.csproj
+++ b/ModUpdateDate/ModUpdateDate.csproj
@@ -22,7 +22,7 @@ namespace PeterHan.ModUpdateDate {
     <Reference Include="com.rlabrecque.steamworks.net" HintPath="$(GameFolder)/com.rlabrecque.steamworks.net.dll" />
   </ItemGroup>
   <Target Name="WriteModVersionFile" BeforeTargets="PreBuildEvent">
-    <WriteLinesToFile File="$(IntermediateOutputPath)\Version.cs" Overwrite="true" Lines="$(VersionFileContent)"/>
+    <WriteLinesToFile File="$(IntermediateOutputPath)\Version.cs" Overwrite="true" WriteOnlyWhenDifferent="true" Lines="$(VersionFileContent)"/>
   </Target>
   <ItemGroup>
     <Compile Include="$(IntermediateOutputPath)\Version.cs" />

--- a/PLibCore/PLibCore.csproj
+++ b/PLibCore/PLibCore.csproj
@@ -25,7 +25,7 @@ namespace PeterHan.PLib {
     <DocumentationFile>bin\$(Platform)\Release\PLibCore.xml</DocumentationFile>
   </PropertyGroup>
   <Target Name="WriteModVersionFile" BeforeTargets="PreBuildEvent">
-    <WriteLinesToFile File="$(IntermediateOutputPath)\PVersion.cs" Overwrite="true" Lines="$(PLibVersionFileContent)"/>
+    <WriteLinesToFile File="$(IntermediateOutputPath)\PVersion.cs" Overwrite="true" WriteOnlyWhenDifferent="true" Lines="$(PLibVersionFileContent)"/>
   </Target>
   <ItemGroup>
     <Compile Include="$(IntermediateOutputPath)\PVersion.cs" />


### PR DESCRIPTION
Build changes to reduce development build time and redundant disk IO traffic.

The default MSBuild pipelines provide incremental builds to suppress redundant rebuilds of projects/artifacts without source/content changes. However, no project in the solution was building incrementally due to a combination of behaviors:

- [x] 617adb89cf085fee6b9767b168c36041c100c4dd {P}Version files are written on every build, so each project is always dirty for rebuild.
- [x] 4d92c52573bb81c8ff940f73ac5d2b0d2979bede ILRepack requires inputs/outputs configuration to track dirty files and repack output.

> [!NOTE]
> Incremental builds also support 'clean' targets by tracking file changes and file writes. So the 'clean' target should now clear 'bin' output thoroughly.

After resolving these issues, we measure the build time before and after the changes summarized below.

### Results

|       | Before | After | Change |
|-------|--------|-------|--------|
| Clean→Build | 18.82 s  | 16.87 s | -10.3% |
| Build→Build | 10.18 s  | 01.03 s | -89.8% |

Change in build time using 4 cores:

- Clean→Build decreases **-10.3%** from **18.82 s** to **16.87 s**
- Build→Build decreases **-89.8%** from **10.18 s** to **01.03 s**

### Benchmark setup

Branch before 'main' and after 'incremental-repack'. We sequence 3 targets: clean→build→build to highlight the build improvement between development phases. Additionally, we control the environment for relatable metrics:

- git-clone to isolate each branch (and mitigate file cache effects)
- restrict build to 4 cores `-m:4` (standard GitHub runner estimate)

<details>
<summary>Reference setup script for the benchmark.</summary>
The benchmark setup is simple in an attempt to mitigate the influence of the file cache. However, accuracy is not the focus of these metrics.

```pwsh
PS> git clone -b BRANCH ONI-Mods TESTPATH 
PS> dotnet clean -c:Release -m:4
PS> dotnet build -c:Release -m:4 --no-restore
Time Elapsed 00:00:16.87
PS> dotnet build -c:Release -m:4 --no-restore
Time Elapsed 00:00:01.03
```
</details>