### PR TITLE
PPatchTools.ReplaceConstant() support Ldc_I4_S sbyte operand

### DIFF
--- a/PLibCore/PPatchTools.cs
+++ b/PLibCore/PPatchTools.cs
@@ -786,8 +786,9 @@ namespace PeterHan.PLib.Core {
 				var opcode = inst.opcode;
 				object operand = inst.operand;
 				if ((opcode == OpCodes.Ldc_I4 && (operand is int ival) && ival == oldValue) ||
-						(opcode == OpCodes.Ldc_I4_S && (operand is byte bval) && bval ==
-						oldValue) || (quickCode && qc == opcode)) {
+						(opcode == OpCodes.Ldc_I4_S && ((operand is byte bval && bval ==
+						oldValue) || (operand is sbyte sbval && sbval == oldValue))) || 
+						(quickCode && qc == opcode)) {
 					// Replace instruction if first instance, or all to be replaced
 					if (all || replaced == 0)
 						PTranspilerTools.ModifyLoadI4(inst, newValue);

--- a/PLibCore/PTranspilerTools.cs
+++ b/PLibCore/PTranspilerTools.cs
@@ -309,7 +309,7 @@ namespace PeterHan.PLib.Core {
 				// Short form: -128 to 127 -- looks like Harmony has issues with emitting
 				// the operand as a Byte
 				instruction.opcode = OpCodes.Ldc_I4_S;
-				instruction.operand = newValue;
+				instruction.operand = (sbyte)newValue;
 			} else {
 				// Long form
 				instruction.opcode = OpCodes.Ldc_I4;


### PR DESCRIPTION
Currently PPatchTools.ReplaceConstant() cannot actually replace constant if Ldc_I4_S instruction operand is sbyte