### PR TITLE
Set side screen targets before sorting

### DIFF
--- a/FastTrack/UIPatches/DetailsPanelWrapper.cs
+++ b/FastTrack/UIPatches/DetailsPanelWrapper.cs
@@ -143,10 +143,10 @@ namespace PeterHan.FastTrack.UIPatches {
 								targetTab.bodyInstance);
 							screen.screenInstance = inst;
 						}
+						inst.SetTarget(target);
 						int sortOrder = inst.GetSideScreenSortOrder();
 						if (!dss.activeInHierarchy)
 							dss.SetActive(true);
-						inst.SetTarget(target);
 						inst.Show();
 						sortedScreens.Add(new SideScreenPair(screen, sortOrder));
 						anyScreens = true;


### PR DESCRIPTION
`LoreBearerSideScreen.GetSideScreenSortOrder()` now delegates to `this.target.GetSideScreenSortOrder()`. When the `LoreBearerSideScreen` is created by `Util.KInstantiateUI` the target remains null until `SetTarget()` is called.

This moves `inst.SetTarget()` to occur before `GetSideScreenSortOrder` is called

Fixes #661 in my testing and does not seem to break any other panels I've tested.

Here is a copy of my build: [FastTrack-661.zip](https://github.com/user-attachments/files/25397031/FastTrack-661.zip)
