### PR TITLE
PLibOptions: generalize RequireDLC() and add RequireMod()

### DIFF
--- a/PLibOptions/OptionsEntry.cs
+++ b/PLibOptions/OptionsEntry.cs
@@ -214,7 +214,7 @@ namespace PeterHan.PLib.Options {
 			var indexes = prop.GetIndexParameters();
 			if (indexes.Length < 1) {
 				var attributes = ListPool<Attribute, OptionsEntry>.Allocate();
-				bool dlcMatch = true, restart = false;
+				bool dlcMatch = true, modMatch = true, restart = false;
 				attributes.AddRange(prop.GetCustomAttributes());
 				int n = attributes.Count;
 				for (int i = 0; i < n; i++) {
@@ -223,10 +223,14 @@ namespace PeterHan.PLib.Options {
 					if (attr is RequireDLCAttribute requireDLC && PGameUtils.IsDLCOwned(
 							requireDLC.DlcID) != requireDLC.Required)
 						dlcMatch = false;
+					// Do not create an entry if the required mod is not enabled
+					else if (attr is RequireModAttribute requireMod && !Util.IsModEnabled(
+						requireMod.ModStaticID))
+						modMatch = false;
 					else if (attr is RestartRequiredAttribute)
 						restart = true;
 				}
-				if (dlcMatch)
+				if (dlcMatch && modMatch)
 					for (int i = 0; i < n; i++) {
 						result = TryCreateEntry(attributes[i], prop, depth, restart);
 						if (result != null)

--- a/PLibOptions/RequireDLCAttribute.cs
+++ b/PLibOptions/RequireDLCAttribute.cs
@@ -25,7 +25,8 @@ namespace PeterHan.PLib.Options {
 	/// show or hide it for particular DLCs. If the option is hidden, the value currently
 	/// in the options file is preserved unchanged when reading or writing.
 	/// </summary>
-	[AttributeUsage(AttributeTargets.Property, AllowMultiple = true, Inherited = true)]
+	[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = true,
+		Inherited = true)]
 	public sealed class RequireDLCAttribute : Attribute {
 		/// <summary>
 		/// The DLC ID to check.
@@ -42,8 +43,9 @@ namespace PeterHan.PLib.Options {
 		/// Annotates an option field as requiring the specified DLC. The [Option] attribute
 		/// must also be present to be displayed at all.
 		/// </summary>
-		/// <param name="dlcID">The DLC ID to require. Must be one of:
-		/// DlcManager.EXPANSION1_ID, DlcManager.VANILLA_ID</param>
+		/// <param name="dlcID">The DLC ID to require. Common values include:
+		/// DlcManager.EXPANSION1_ID, DlcManager.DLC2_ID, DlcManager.DLC4_ID,
+		/// or DlcManager.VANILLA_ID</param>
 		public RequireDLCAttribute(string dlcID) {
 			DlcID = dlcID;
 			Required = true;
@@ -53,8 +55,9 @@ namespace PeterHan.PLib.Options {
 		/// Annotates an option field as requiring or forbidding the specified DLC. The
 		/// [Option] attribute must also be present to be displayed at all.
 		/// </summary>
-		/// <param name="dlcID">The DLC ID to require or forbid. Must be one of:
-		/// DlcManager.EXPANSION1_ID, DlcManager.VANILLA_ID</param>
+		/// <param name="dlcID">The DLC ID to require or forbid. Common values include:
+		/// DlcManager.EXPANSION1_ID, DlcManager.DLC2_ID, DlcManager.DLC4_ID,
+		/// or DlcManager.VANILLA_ID</param>
 		/// <param name="required">true to require the DLC, or false to forbid it.</param>
 		public RequireDLCAttribute(string dlcID, bool required) {
 			DlcID = dlcID ?? "";

--- a/PLibOptions/RequireModAttribute.cs
+++ b/PLibOptions/RequireModAttribute.cs
@@ -1,0 +1,31 @@
+﻿
+using PeterHan.PLib.Core;
+using System;
+
+namespace PeterHan.PLib.Options {
+	/// An attribute placed on an option property for a class used as mod options in order to
+	/// show or hide it for an arbitrary condition.. If the option is hidden, the value
+	// currently in the options file is preserved unchanged when reading or writing.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = true,
+		Inherited = true)]
+	public sealed class RequireModAttribute : Attribute {
+		/// <summary>
+		/// The Mod to check.
+		/// </summary>
+		public string ModStaticID { get; }
+
+		/// <summary>
+		/// Annotates an option field as requiring the specified Mod. The [Option]
+		// attribute must also be present to be displayed at all.
+		/// </summary>
+		/// <param name="cond">The Mod required to be present
+		public RequireModAttribute(string modStaticIDIn) {
+			this.ModStaticID = modStaticIDIn;
+		}
+
+		public override string ToString() {
+			return "RequireMod[ModStaticID={0}]".F(ModStaticID);
+		}
+	}
+}

--- a/PLibOptions/SelectOneOptionsEntry.cs
+++ b/PLibOptions/SelectOneOptionsEntry.cs
@@ -20,6 +20,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.Serialization;
+using PeterHan.PLib.Core;
 using PeterHan.PLib.UI;
 using UnityEngine;
 
@@ -28,6 +29,40 @@ namespace PeterHan.PLib.Options {
 	/// An options entry which represents Enum and displays a spinner with text options.
 	/// </summary>
 	public class SelectOneOptionsEntry : OptionsEntry {
+		/// <summary>
+		/// Determines whether an enum member should be displayed based on its
+		/// RequireDLCAttribute(s).
+		/// </summary>
+		/// <param name="member">The enum member info.</param>
+		/// <returns>true if the enum member should be included, or false if it should be hidden.</returns>
+		private static bool MatchesDLC(MemberInfo member) {
+			bool dlcMatch = true;
+			foreach (var attrib in member.GetCustomAttributes(false))
+				if (attrib is RequireDLCAttribute requireDLC && PGameUtils.IsDLCOwned(
+						requireDLC.DlcID) != requireDLC.Required) {
+					dlcMatch = false;
+					break;
+				}
+			return dlcMatch;
+		}
+
+		/// <summary>
+		/// Determines whether an enum member should be displayed based on its
+		/// RequireModAttribute(s).
+		/// </summary>
+		/// <param name="member">The enum member info.</param>
+		/// <returns>true if the enum member should be included, or false if it should be hidden.</returns>
+		private static bool MatchesMod(MemberInfo member) {
+			bool modMatch = true;
+			foreach (var attrib in member.GetCustomAttributes(false))
+				if (attrib is RequireModAttribute requireMod && !Util.IsModEnabled(
+						requireMod.ModStaticID)) {
+					modMatch = false;
+					break;
+				}
+			return modMatch;
+		}
+
 		/// <summary>
 		/// Obtains the title and tool tip for an enumeration value.
 		/// </summary>
@@ -101,8 +136,20 @@ namespace PeterHan.PLib.Options {
 			chosen = null;
 			comboBox = null;
 			options = new List<EnumOption>(n);
-			for (int i = 0; i < n; i++)
-				options.Add(GetAttribute(eval.GetValue(i), fieldType));
+			for (int i = 0; i < n; i++) {
+				object value = eval.GetValue(i);
+				string valueName = value?.ToString() ?? "";
+				// Filter based on requirement attributes applied to enum members
+				bool include = true;
+				foreach (var enumField in fieldType.GetMember(valueName, BindingFlags.Public |
+						BindingFlags.Static))
+					if (enumField.DeclaringType == fieldType) {
+						include = MatchesDLC(enumField) && MatchesMod(enumField);
+						break;
+					}
+				if (include)
+					options.Add(GetAttribute(value, fieldType));
+			}
 		}
 
 		public override GameObject GetUIComponent() {

--- a/PLibOptions/Util.cs
+++ b/PLibOptions/Util.cs
@@ -1,0 +1,15 @@
+
+namespace PeterHan.PLib.Options;
+
+public class Util {
+	// Returns true if the specified mod is installed & enabled
+	public static bool IsModEnabled(string staticID) {
+		foreach(var mod in Global.Instance.modManager.mods) {
+			if (mod.staticID == staticID && mod.IsActive()) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+}


### PR DESCRIPTION
This commit generalizes RequireDLC() to work with enum values. Additionally it introduces a RequireMod() attribute which is functionally equivalent to RequireDLC() except that it checks for whether a module is loaded.

Example usage of the change to RequireDLC():

https://github.com/mikeb26/ONIMods/blob/main/CGSM/Planetoids.cs#L184

Example usage of RequireMod():

https://github.com/mikeb26/ONIMods/blob/main/CGSM/Planetoids.cs#L164