### PR TITLE
Fast Track: Improve mod compatibility of side screen patches

### DIFF
--- a/FastTrack/UIPatches/SimpleInfoScreenWrapper.cs
+++ b/FastTrack/UIPatches/SimpleInfoScreenWrapper.cs
@@ -721,7 +721,8 @@ namespace PeterHan.FastTrack.UIPatches {
 		private void UpdatePanels() {
 			var vitalsPanel = sis.vitalsPanel;
 			RefreshStress();
-			RefreshStorage();
+			// Allow mods' prefixes to run, our prefix still runs
+			SimpleInfoScreen.RefreshStoragePanel(sis.StoragePanel, sis.selectedTarget);
 			RefreshMove();
 			RefreshFertility();
 			if (vitalsActive) {


### PR DESCRIPTION
Instead of calling Fast Track's own `RefreshStorage` function directly, call the original `SimpleInfoScreen.RefreshStoragePanel` function. This way, other mods' prefixes on `SimpleInfoScreen.RefreshStoragePanel` can still run before the optimised `RefreshStorage` function is called from a low priority prefix skip in Fast Track.